### PR TITLE
Add support for zio-macros (0.5.0) @accessible annotation

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,10 @@
 
     <depends>org.intellij.scala</depends>
 
+    <extensions defaultExtensionNs="org.intellij.scala">
+        <syntheticMemberInjector implementation="zio.intellij.synthetic.macros.ModulePatternAccessible"/>
+    </extensions>
+
     <extensions defaultExtensionNs="com.intellij">
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyUnitInspection"
                          displayName="Simplify returning Unit to .unit" groupPath="Scala,ZIO" groupName="Simplifications"

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
@@ -1,0 +1,48 @@
+package zio.intellij.synthetic.macros
+
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScAnnotation
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDeclaration
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.impl.base.ScLiteralImpl
+import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
+import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
+
+class ModulePatternAccessible extends SyntheticMembersInjector {
+
+  private def annotationFirstParam(scAnnotation: ScAnnotation): Option[String] =
+    scAnnotation.annotationExpr.getAnnotationParameters.collectFirst {
+      case sl: ScLiteralImpl => sl.getValue()
+    }
+
+  private def helperObjectExtension(annotation: ScAnnotation, sco: ScObject): Seq[String] =
+    annotationFirstParam(annotation)
+      .map(name => s"def $name : ${sco.qualifiedName}.Service[R] = ???")
+      .toSeq
+
+  private def accessorTraitExtension(sco: ScObject): String = {
+    val serviceTrait = sco.typeDefinitions.find(_.name == "Service")
+    val signatures = serviceTrait.toSeq.flatMap(_.allMethods).collect {
+      case PhysicalMethodSignature(method: ScFunctionDeclaration, _) => s"${method.getText} = ???"
+    }
+
+    s"""trait Accessors extends ${sco.qualifiedName}.Service[${sco.name}] {" +
+           ${signatures.mkString("\n")}
+        }"""
+  }
+
+  private def findAccessibleMacroAnnotation(sco: ScObject): Option[ScAnnotation] = {
+    val companion = sco.fakeCompanionClassOrCompanionClass
+    Option(companion.getAnnotation("zio.macros.annotation.accessible")).collect {
+      case a: ScAnnotation => a
+    }
+  }
+
+  override def injectMembers(source: ScTypeDefinition): Seq[String] =
+    source match {
+      case sco: ScObject =>
+        val annotation = findAccessibleMacroAnnotation(sco)
+        annotation.map(a => helperObjectExtension(a, sco) :+ accessorTraitExtension(sco)).getOrElse(Nil)
+      case _ =>
+        Nil
+    }
+}


### PR DESCRIPTION
Resolves #17 

This PR adds autocomplete support for people using `@accessible` `zio-macros` from the `0.5.0` release.

It works with both the plain `@accessible` and the version that creates a helper object (e.g. `@accessible(">")`

No dependencies on `zio-macro` are introduced.