### PR TITLE
Correctly infer R type when using an environment accessor

### DIFF
--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
@@ -16,7 +16,7 @@ class ModulePatternAccessible extends SyntheticMembersInjector {
 
   private def helperObjectExtension(annotation: ScAnnotation, sco: ScObject): Seq[String] =
     annotationFirstParam(annotation)
-      .map(name => s"def $name : ${sco.qualifiedName}.Service[R] = ???")
+      .map(name => s"def $name : ${sco.qualifiedName}.Service[${sco.qualifiedName}] = ???")
       .toSeq
 
   private def accessorTraitExtension(sco: ScObject): String = {


### PR DESCRIPTION
This is a quick addition to the previous pull request that improves the type inference when using the accessory.

 Previously the R parameter would be inferred by intellij as `Any` when it should actually be the service trait. 