### PR TITLE
Adding tests + test fixtures!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories() {
 
 dependencies {
     compileOnly 'org.scala-lang:scala-library:2.12.7'
+    testCompileOnly 'org.scala-lang:scala-library:2.12.7'
 }
 
 patchPluginXml {

--- a/src/main/resources/inspectionDescriptions/SimplifySucceedOptionInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifySucceedOptionInspection.html
@@ -1,0 +1,8 @@
+<html>
+<body>Simplify the following expressions to use <code>.none/some</code> instead:
+<pre>
+ZIO.succeed(None)   -> ZIO.none
+ZIO.succeed(Some(a) -> ZIO.some(a)
+</pre>
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
@@ -4,7 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
 
-class SimplifySucceedOptionInspection extends ZInspection(NoneSimplificationType)
+class SimplifySucceedOptionInspection extends ZInspection(NoneSimplificationType, SomeSimplificationType)
 
 object NoneSimplificationType extends SimplificationType {
   override def hint: String = "Replace with ZIO.none"

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyWhenInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyWhenInspection.scala
@@ -10,11 +10,13 @@ object WhenSimplificationType extends SimplificationType {
   override def hint: String = "Replace with .when"
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
-    def replacement(ifStmt: ScExpression, arg: ScReferenceExpression, cond: ScExpression) =
-      replace(ifStmt).withText(s"${arg.getText}.when(${cond.getText})")
+    def replacement(ifStmt: ScExpression, tb: ScReferenceExpression, arg: ScExpression, cond: ScExpression) = {
+      val refText = if (tb == arg) tb.getText else s"${tb.getText}(${arg.getText})"
+      replace(ifStmt).withText(s"$refText.when(${cond.getText})")
+    }
 
     expr match {
-      case cond @ IfStmt(condition, tb @ zioRef(), `ZIO.unit`(_)) => Some(replacement(cond, tb, condition))
+      case cond @ IfStmt(condition, zioRef(tb, e), `ZIO.unit`(_)) => Some(replacement(cond, tb, e, condition))
       case _                                                      => None
     }
   }

--- a/src/test/scala/intellij/testfixtures/FailableTest.scala
+++ b/src/test/scala/intellij/testfixtures/FailableTest.scala
@@ -1,0 +1,18 @@
+package org.jetbrains.plugins.scala.base
+
+import org.junit.Assert
+
+trait FailableTest {
+  /**
+   * A hook to allow tests that are currently failing to pass when they fail and vice versa.
+   * @return
+   */
+  protected def shouldPass: Boolean = true
+
+  protected def assertEqualsFailable(expected: AnyRef, actual: AnyRef): Unit = {
+    if (shouldPass) Assert.assertEquals(expected, actual)
+    else Assert.assertNotEquals(expected, actual)
+  }
+
+  val failingPassed: String = "Test has passed, but was supposed to fail"
+}

--- a/src/test/scala/intellij/testfixtures/IvyManagedLoader.scala
+++ b/src/test/scala/intellij/testfixtures/IvyManagedLoader.scala
@@ -1,0 +1,19 @@
+package org.jetbrains.plugins.scala
+package base
+package libraryLoaders
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.PsiTestUtil
+import org.jetbrains.plugins.scala.DependencyManagerBase.DependencyDescription
+
+case class IvyManagedLoader(dependencies: DependencyDescription*) extends LibraryLoader {
+  protected lazy val dependencyManager: DependencyManagerBase = DependencyManager
+
+  override def init(implicit module: Module, version: ScalaVersion): Unit = {
+    dependencyManager.resolve(dependencies: _*).foreach { resolved =>
+      VfsRootAccess.allowRootAccess(resolved.file.getCanonicalPath)
+      PsiTestUtil.addLibrary(module, resolved.info.toString, resolved.file.getParent, resolved.file.getName)
+    }
+  }
+}

--- a/src/test/scala/intellij/testfixtures/LibraryLoader.scala
+++ b/src/test/scala/intellij/testfixtures/LibraryLoader.scala
@@ -1,0 +1,14 @@
+package org.jetbrains.plugins.scala
+package base
+package libraryLoaders
+
+import com.intellij.openapi.module.Module
+
+/**
+ * @author adkozlov
+ */
+trait LibraryLoader {
+  def init(implicit module: Module, version: ScalaVersion)
+
+  def clean(implicit module: Module): Unit = ()
+}

--- a/src/test/scala/intellij/testfixtures/OperationsOnCollectionInspectionTest.scala
+++ b/src/test/scala/intellij/testfixtures/OperationsOnCollectionInspectionTest.scala
@@ -1,0 +1,21 @@
+package org.jetbrains.plugins.scala
+package codeInspection.collections
+
+import org.jetbrains.plugins.scala.codeInspection.ScalaQuickFixTestBase
+
+/**
+ * Nikolay.Tropin
+ * 5/21/13
+ */
+abstract class OperationsOnCollectionInspectionTest extends ScalaQuickFixTestBase {
+  protected val classOfInspection: Class[_ <: OperationOnCollectionInspection]
+
+  protected val hint: String
+
+  override protected lazy val description: String = hint
+
+  protected def doTest(selected: String, text: String, result: String): Unit = {
+    checkTextHasError(selected)
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/intellij/testfixtures/ScalaHighlightsTestBase.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaHighlightsTestBase.scala
@@ -1,0 +1,190 @@
+package org.jetbrains.plugins.scala
+package codeInspection
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInspection.ex.ScopeToolState
+import com.intellij.codeInspection.{LocalInspectionEP, LocalInspectionTool}
+import com.intellij.openapi.editor.SelectionModel
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.util.TextRange
+import com.intellij.profile.codeInspection.ProjectInspectionProfileManager
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter.{findCaretOffset, normalize}
+import org.jetbrains.plugins.scala.extensions.executeWriteActionCommand
+import org.junit.Assert._
+
+import scala.collection.JavaConverters
+
+abstract class ScalaHighlightsTestBase extends ScalaLightCodeInsightFixtureTestAdapter {
+  self: ScalaLightCodeInsightFixtureTestAdapter =>
+
+  import ScalaHighlightsTestBase._
+
+  protected val description: String
+
+  protected val fileType: LanguageFileType = ScalaFileType.INSTANCE
+
+  protected def descriptionMatches(s: String): Boolean = s == normalize(description)
+
+  protected override def checkTextHasNoErrors(text: String): Unit = {
+    val ranges = findRanges(text)
+    assertTrue(if (shouldPass) s"Highlights found at: ${ranges.mkString(", ")}." else failingPassed,
+      !shouldPass ^ ranges.isEmpty)
+  }
+
+  protected def checkTextHasError(text: String, allowAdditionalHighlights: Boolean = false): Unit = {
+    val actualRanges = findRanges(text)
+    val expectedRange = selectedRange(getEditor.getSelectionModel)
+    checkTextHasError(Seq(expectedRange), actualRanges, allowAdditionalHighlights)
+  }
+
+  protected def checkTextHasError(expectedHighlightRanges: Seq[TextRange],
+                                  actualHighlightRanges: Seq[TextRange],
+                                  allowAdditionalHighlights: Boolean): Unit = {
+    val expectedRangesNotFound = expectedHighlightRanges.filterNot(actualHighlightRanges.contains)
+    if (shouldPass) {
+      assertTrue(s"Highlights not found: $description", actualHighlightRanges.nonEmpty)
+      assertTrue(
+        s"Highlights found at: ${actualHighlightRanges.mkString(", ")}, " +
+          s"not found: ${expectedRangesNotFound.mkString(", ")}",
+        expectedRangesNotFound.isEmpty)
+      val duplicatedHighlights = actualHighlightRanges
+        .groupBy(identity)
+        .mapValues(_.length)
+        .toSeq
+        .collect { case (highlight, count) if count > 1 => highlight }
+
+      assertTrue(s"Some highlights were duplicated: ${duplicatedHighlights.mkString(", ")}", duplicatedHighlights.isEmpty)
+      if (!allowAdditionalHighlights) {
+        assertTrue(
+          s"Found too many highlights: ${actualHighlightRanges.mkString(", ")}, " +
+            s"expected: ${expectedHighlightRanges.mkString(", ")}",
+          actualHighlightRanges.length == expectedHighlightRanges.length
+        )
+      }
+    } else {
+      assertTrue(failingPassed, actualHighlightRanges.isEmpty)
+      assertFalse(failingPassed, expectedRangesNotFound.isEmpty)
+    }
+  }
+
+  protected def findRanges(text: String): Seq[TextRange] = configureByText(text).map(_._2)
+
+  protected def configureByText(text: String): Seq[(HighlightInfo, TextRange)] = {
+    val fileText = createTestText(text)
+    val (normalizedText, offset) = findCaretOffset(fileText, stripTrailingSpaces = true)
+
+    val fixture = getFixture
+    fixture.configureByText(fileType, normalizedText)
+
+    import JavaConverters._
+    val highlightInfos = fixture.doHighlighting().asScala
+      .filter(it => descriptionMatches(it.getDescription))
+    highlightInfos
+      .map(info => (info, highlightedRange(info)))
+      .filter(checkOffset(_, offset))
+  }
+
+  protected def createTestText(text: String): String = text
+
+  protected def selectedRange(model: SelectionModel): TextRange =
+    new TextRange(model.getSelectionStart, model.getSelectionEnd)
+}
+
+object ScalaHighlightsTestBase {
+  private def highlightedRange(info: HighlightInfo): TextRange =
+    new TextRange(info.getStartOffset, info.getEndOffset)
+
+  private def checkOffset(pair: (HighlightInfo, TextRange), offset: Int): Boolean = pair match {
+    case _ if offset == -1 => true
+    case (_, range) => range.containsOffset(offset)
+  }
+}
+
+abstract class ScalaQuickFixTestBase extends ScalaInspectionTestBase
+
+abstract class ScalaAnnotatorQuickFixTestBase extends ScalaHighlightsTestBase {
+  import ScalaAnnotatorQuickFixTestBase.quickFixes
+
+  protected def testQuickFix(text: String, expected: String, hint: String): Unit = {
+    val maybeAction = findQuickFix(text, hint)
+    assertFalse(s"Quick fix not found: $hint", maybeAction.isEmpty)
+
+    executeWriteActionCommand() {
+      maybeAction.get.invoke(getProject, getEditor, getFile)
+    }(getProject)
+
+    val expectedFileText = createTestText(expected)
+    getFixture.checkResult(normalize(expectedFileText), /*stripTrailingSpaces = */ true)
+  }
+
+  protected def checkNotFixable(text: String, hint: String): Unit = {
+    val maybeAction = findQuickFix(text, hint)
+    assertTrue("Quick fix found.", maybeAction.isEmpty)
+  }
+
+  protected def checkIsNotAvailable(text: String, hint: String): Unit = {
+    val maybeAction = findQuickFix(text, hint)
+    assertTrue("Quick fix not found.", maybeAction.nonEmpty)
+    assertTrue("Quick fix is available", maybeAction.forall(action => !action.isAvailable(getProject, getEditor, getFile)))
+  }
+
+  private def findQuickFix(text: String, hint: String): Option[IntentionAction] =
+    configureByText(text).map(_._1) match {
+      case Seq() =>
+        fail("Errors not found.")
+        null
+      case seq => seq.flatMap(quickFixes).find(_.getText == hint)
+    }
+}
+
+object ScalaAnnotatorQuickFixTestBase {
+  private def quickFixes(info: HighlightInfo): Seq[IntentionAction] = {
+    import JavaConverters._
+    Option(info.quickFixActionRanges).toSeq
+      .flatMap(_.asScala)
+      .flatMap(pair => Option(pair))
+      .map(_.getFirst.getAction)
+  }
+}
+
+abstract class ScalaInspectionTestBase extends ScalaAnnotatorQuickFixTestBase {
+
+  protected val classOfInspection: Class[_ <: LocalInspectionTool]
+
+  protected override def setUp(): Unit = {
+    super.setUp()
+    getFixture.enableInspections(classOfInspection)
+  }
+}
+
+trait ForceInspectionSeverity extends ScalaInspectionTestBase {
+
+  private var oldLevel: HighlightDisplayLevel = _
+  protected override def setUp(): Unit = {
+    super.setUp()
+    val toolState = inspectionToolState
+    oldLevel = toolState.getLevel
+    toolState.setLevel(forcedInspectionSeverity)
+  }
+
+  override def tearDown(): Unit = {
+    inspectionToolState.setLevel(oldLevel)
+    super.tearDown()
+  }
+
+  private def inspectionToolState: ScopeToolState = {
+    val profile = ProjectInspectionProfileManager.getInstance(getFixture.getProject).getCurrentProfile
+    profile.getToolDefaultState(inspectionEP.getShortName, getFixture.getProject)
+  }
+
+  private def inspectionEP =
+    LocalInspectionEP.LOCAL_INSPECTION
+      .getExtensions
+      .find(_.implementationClass == classOfInspection.getCanonicalName)
+      .get
+
+  protected def forcedInspectionSeverity: HighlightDisplayLevel
+}

--- a/src/test/scala/intellij/testfixtures/ScalaLightCodeInsightFixtureTestAdapter.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaLightCodeInsightFixtureTestAdapter.scala
@@ -1,0 +1,168 @@
+package org.jetbrains.plugins.scala
+package base
+
+import com.intellij.application.options.CodeStyle
+import com.intellij.codeInsight.folding.CodeFoldingManager
+import com.intellij.openapi.actionSystem.IdeActions
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.vfs.{VfsUtil, VirtualFile}
+import com.intellij.psi.codeStyle.{CodeStyleSettings, CommonCodeStyleSettings}
+import com.intellij.psi.{PsiDocumentManager, PsiFile}
+import com.intellij.testFramework.fixtures.{JavaCodeInsightTestFixture, LightJavaCodeInsightFixtureTestCase}
+import com.intellij.testFramework.{EditorTestUtil, LightPlatformTestCase, LightProjectDescriptor}
+import org.jetbrains.plugins.scala.extensions.invokeAndWait
+import org.jetbrains.plugins.scala.lang.formatting.settings.ScalaCodeStyleSettings
+import org.junit.Assert.{assertNotNull, fail}
+
+/**
+ * User: Dmitry Naydanov
+ * Date: 3/5/12
+ */
+abstract class ScalaLightCodeInsightFixtureTestAdapter
+  extends LightJavaCodeInsightFixtureTestCase with ScalaSdkOwner with TestFixtureProvider with FailableTest {
+
+  import ScalaLightCodeInsightFixtureTestAdapter._
+  import libraryLoaders._
+
+  val CARET = EditorTestUtil.CARET_TAG
+
+  override final def getFixture: JavaCodeInsightTestFixture = myFixture
+
+  override def getTestDataPath: String = util.TestUtils.getTestDataPath + "/"
+
+  protected def loadScalaLibrary: Boolean = true
+
+  override protected def librariesLoaders: Seq[LibraryLoader] = Seq(
+    ScalaSDKLoader()
+  )
+
+  override protected def getProjectDescriptor: LightProjectDescriptor = new ScalaLightProjectDescriptor() {
+    override def tuneModule(module: Module): Unit = setUpLibraries(module)
+    override def getSdk: Sdk = SmartJDKLoader.getOrCreateJDK()
+  }
+
+  override def setUpLibraries(implicit module: Module): Unit = {
+    Registry.get("ast.loading.filter").setValue(true, getTestRootDisposable)
+    if (loadScalaLibrary) {
+      getFixture.allowTreeAccessForAllFiles()
+      super.setUpLibraries(module)
+    }
+  }
+
+  override protected def tearDown(): Unit = {
+    disposeLibraries(getModule)
+    super.tearDown()
+  }
+
+  protected def configureFromFileText(fileText: String): PsiFile = {
+    val file = getFixture.configureByText(
+      ScalaFileType.INSTANCE,
+      normalize(fileText)
+    )
+    assertNotNull(file)
+    file
+  }
+
+  protected def checkTextHasNoErrors(text: String): Unit = {
+    getFixture.configureByText(
+      ScalaFileType.INSTANCE,
+      text
+    )
+    CodeFoldingManager.getInstance(getProject).buildInitialFoldings(getEditor)
+
+    if (shouldPass) {
+      testHighlighting(getFile.getVirtualFile)
+    } else {
+      try {
+        testHighlighting(getFile.getVirtualFile)
+      } catch {
+        case _: AssertionError => return
+      }
+      failingTestPassed()
+    }
+  }
+
+  protected def failingTestPassed(): Unit = throw new RuntimeException(failingPassed)
+
+  protected def getCurrentCodeStyleSettings: CodeStyleSettings = CodeStyle.getSettings(getProject)
+
+  protected def getCommonSettings: CommonCodeStyleSettings = getCurrentCodeStyleSettings.getCommonSettings(ScalaLanguage.INSTANCE)
+
+  protected def getScalaSettings: ScalaCodeStyleSettings = getCurrentCodeStyleSettings.getCustomSettings(classOf[ScalaCodeStyleSettings])
+
+  private def testHighlighting(virtualFile: VirtualFile): Unit = getFixture.testHighlighting(
+    false,
+    false,
+    false,
+    virtualFile
+  )
+
+  protected def changePsiAt(offset: Int): Unit = {
+    invokeAndWait {
+      getEditor.getCaretModel.moveToOffset(offset)
+      myFixture.`type`('a')
+      commitDocument()
+      myFixture.performEditorAction(IdeActions.ACTION_EDITOR_BACKSPACE)
+      commitDocument()
+    }
+  }
+
+  private def commitDocument(): Unit = PsiDocumentManager.getInstance(getProject).commitDocument(getEditor.getDocument)
+}
+
+object ScalaLightCodeInsightFixtureTestAdapter {
+
+  def normalize(text: String, stripTrailingSpaces: Boolean = true): String =
+    text.stripMargin.replace("\r", "") match {
+      case result if stripTrailingSpaces => result.trim
+      case result => result
+    }
+
+  def findCaretOffset(text: String, stripTrailingSpaces: Boolean): (String, Int) = {
+    val (textActual, caretOffsets) = findCaretOffsets(text, stripTrailingSpaces)
+    caretOffsets match {
+      case Seq(caretIdx) => (textActual, caretIdx)
+      case Seq()         => (textActual, -1)
+      case _             => fail(s"single caret expected but found: ${caretOffsets.size}").asInstanceOf[Nothing]
+    }
+  }
+
+  def findCaretOffsets(text: String, stripTrailingSpaces: Boolean): (String, Seq[Int]) = {
+    import EditorTestUtil.CARET_TAG
+
+    val textNormalized = normalize(text, stripTrailingSpaces)
+
+    def caretIndex(offset: Int) = textNormalized.indexOf(CARET_TAG, offset)
+
+    @scala.annotation.tailrec
+    def collectCaretIndices(idx: Int)(indices: Seq[Int]): Seq[Int] =
+      if (idx < 0) indices else {
+        val nextIdx = caretIndex(idx + 1)
+        collectCaretIndices(nextIdx)(indices :+ idx)
+      }
+
+    val caretIndices = collectCaretIndices(caretIndex(0))(Seq[Int]())
+    val caretIndicesNormalized = caretIndices.zipWithIndex.map { case (caretIdx, idx) => caretIdx - idx * CARET_TAG.length }
+    (
+      textNormalized.replace(CARET_TAG, ""),
+      caretIndicesNormalized
+    )
+  }
+
+  implicit class Ext(private val adapter: ScalaLightCodeInsightFixtureTestAdapter) extends AnyVal {
+
+    def configureJavaFile(fileText: String,
+                          className: String,
+                          packageName: String = null): Unit = inWriteAction {
+      val root = LightPlatformTestCase.getSourceRoot match {
+        case sourceRoot if packageName == null => sourceRoot
+        case sourceRoot => sourceRoot.createChildDirectory(null, packageName)
+      }
+
+      val file = root.createChildData(null, className + ".java")
+      VfsUtil.saveText(file, normalize(fileText))
+    }
+  }
+}

--- a/src/test/scala/intellij/testfixtures/ScalaLightProjectDescriptor.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaLightProjectDescriptor.scala
@@ -1,0 +1,30 @@
+package org.jetbrains.plugins.scala.base
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.LightProjectDescriptor
+
+class ScalaLightProjectDescriptor extends LightProjectDescriptor {
+
+  private var myModule: Module = _
+
+  class SetupHandlerDelegate(delegate: LightProjectDescriptor.SetupHandler) extends LightProjectDescriptor.SetupHandler {
+    override def moduleCreated(module: Module): Unit = {
+      delegate.moduleCreated(module)
+      myModule = module
+      //      tuneModule(module)
+    }
+
+    override def sourceRootCreated(sourceRoot: VirtualFile): Unit = delegate.sourceRootCreated(sourceRoot)
+  }
+
+  override def setUpProject(project: Project, handler: LightProjectDescriptor.SetupHandler): Unit = {
+    super.setUpProject(project, new SetupHandlerDelegate(handler))
+    tuneModule(myModule)
+    myModule = null
+  }
+
+  def tuneModule(module: Module): Unit = ()
+
+}

--- a/src/test/scala/intellij/testfixtures/ScalaSDKLoader.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaSDKLoader.scala
@@ -1,0 +1,117 @@
+package org.jetbrains.plugins.scala
+package base
+package libraryLoaders
+
+import java.io.File
+import java.{util => ju}
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ui.configuration.libraryEditor.ExistingLibraryEditor
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.vfs.{JarFileSystem, VirtualFile}
+import com.intellij.testFramework.PsiTestUtil
+import org.jetbrains.plugins.scala.project.{ModuleExt, ScalaLibraryProperties, ScalaLibraryType, template}
+import org.junit.Assert._
+
+case class ScalaSDKLoader(includeScalaReflect: Boolean = false) extends LibraryLoader {
+
+  private object DependencyManager extends DependencyManagerBase {
+    override protected val artifactBlackList = Set.empty[String]
+  }
+
+  import DependencyManagerBase._
+  import ScalaSDKLoader._
+  import template.Artifact.ScalaCompiler.{versionOf => ScalaCompilerVersion}
+
+  def scalaCompilerDescription(implicit scalaVersion: ScalaVersion): DependencyDescription = scalaDependency("compiler")
+
+  def scalaLibraryDescription(implicit scalaVersion: ScalaVersion): DependencyDescription = scalaDependency("library")
+
+  def scalaReflectDescription(implicit scalaVersion: ScalaVersion): DependencyDescription = scalaDependency("reflect")
+
+  private def scalaDependency(kind: String)
+                             (implicit scalaVersion: ScalaVersion) = {
+    val (org, idPrefix, idSuffix) = scalaVersion match {
+      case Scala_3_0 => ("ch.epfl.lamp", "dotty", "_" + scalaVersion.major)
+      case _ => ("org.scala-lang", "scala", "")
+    }
+
+    DependencyDescription(org, idPrefix + "-" + kind + idSuffix, scalaVersion.minor)
+  }
+
+
+  protected def binaryDependencies(implicit version: ScalaVersion): List[DependencyDescription] =
+    for {
+      descriptor <- scalaCompilerDescription ::
+        scalaLibraryDescription ::
+        scalaReflectDescription ::
+        Nil
+
+      if includeScalaReflect || !descriptor.artId.contains("reflect")
+    } yield descriptor
+
+  protected def sourcesDependency(implicit version: ScalaVersion): DependencyDescription =
+    scalaLibraryDescription % Types.SRC
+
+  final def sourceRoot(implicit version: ScalaVersion): VirtualFile = {
+    val ResolvedDependency(_, file) = DependencyManager.resolveSingle(sourcesDependency)
+    findJarFile(file)
+  }
+
+  override final def init(implicit module: Module, version: ScalaVersion): Unit = {
+    val dependencies = binaryDependencies
+    val resolved = DependencyManager.resolve(dependencies: _*)
+
+    assertEquals(
+      s"Failed to resolve scala sdk version $version, result:\n${resolved.mkString("\n")}",
+      dependencies.size,
+      resolved.size
+    )
+
+    val compilerClasspath = for {
+      ResolvedDependency(_, file) <- resolved
+      if file.exists()
+    } yield file
+
+    assertFalse(
+      s"Local SDK files failed to verify for version $version:\n${resolved.mkString("\n")}",
+      compilerClasspath.isEmpty
+    )
+
+    val classesRoots = {
+      import scala.collection.JavaConverters._
+      compilerClasspath.map(findJarFile).asJava
+    }
+
+    val library = PsiTestUtil.addProjectLibrary(
+      module,
+      s"scala-sdk-${version.minor}",
+      classesRoots,
+      ju.Collections.singletonList(sourceRoot)
+    )
+
+    Disposer.register(module, library)
+    inWriteAction {
+      val properties = ScalaLibraryProperties(
+        ScalaCompilerVersion(compilerClasspath.head),
+        compilerClasspath
+      )
+
+      val editor = new ExistingLibraryEditor(library, null)
+      editor.setType(ScalaLibraryType())
+      editor.setProperties(properties)
+      editor.commit()
+
+      val model = module.modifiableModel
+      model.addLibraryEntry(library)
+      model.commit()
+    }
+  }
+}
+
+object ScalaSDKLoader {
+  private def findJarFile(file: File) =
+    JarFileSystem.getInstance().refreshAndFindFileByPath {
+      file.getCanonicalPath + "!/"
+    }
+}

--- a/src/test/scala/intellij/testfixtures/ScalaSdkOwner.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaSdkOwner.scala
@@ -1,0 +1,68 @@
+package org.jetbrains.plugins.scala
+package base
+
+import com.intellij.openapi.module.Module
+import junit.framework.{Test, TestResult}
+import org.jetbrains.plugins.scala.base.libraryLoaders.LibraryLoader
+
+import scala.collection.immutable.SortedSet
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+trait ScalaSdkOwner extends Test {
+  import ScalaSdkOwner._
+
+  implicit final def version: ScalaVersion = {
+    val allSupportedVersions = allTestVersions.filter(supportedIn)
+    selectVersion(configuredScalaVersion.getOrElse(defaultSdkVersion), allSupportedVersions)
+  }
+
+  protected def supportedIn(version: ScalaVersion): Boolean = true
+
+  protected def librariesLoaders: Seq[LibraryLoader]
+
+  protected lazy val myLoaders: ListBuffer[LibraryLoader] = mutable.ListBuffer.empty[LibraryLoader]
+
+  protected def setUpLibraries(implicit module: Module): Unit = {
+
+    librariesLoaders.foreach { loader =>
+      myLoaders += loader
+      loader.init
+    }
+  }
+
+  protected def disposeLibraries(implicit module: Module): Unit = {
+    myLoaders.foreach(_.clean)
+    myLoaders.clear()
+  }
+
+  abstract override def run(result: TestResult): Unit = {
+    val skip =
+      ScalaSdkOwner.configuredScalaVersion.exists(!supportedIn(_))
+
+    if (!skip) {
+      super.run(result)
+    }
+  }
+}
+
+object ScalaSdkOwner {
+  // todo: eventually move to version Scala_2_13
+  //       (or better, move ScalaLanguageLevel.getDefault to Scala_2_13 and use ScalaVersion.default again)
+  val defaultSdkVersion: ScalaVersion = Scala_2_12 // ScalaVersion.default
+  val allTestVersions: SortedSet[ScalaVersion] = SortedSet(ScalaVersion.allScalaVersions: _*)
+
+  def selectVersion(wantedVersion: ScalaVersion, possibleVersions: SortedSet[ScalaVersion]): ScalaVersion =
+    possibleVersions.iteratorFrom(wantedVersion).toStream.headOption.getOrElse(possibleVersions.last)
+
+  lazy val configuredScalaVersion: Option[ScalaVersion] = {
+    scala.util.Properties.envOrNone("SCALA_SDK_TEST_VERSION").map(
+      ScalaVersion.fromString(_).filter(allTestVersions.contains).getOrElse(
+        throw new AssertionError(
+          "Scala SDK Version specified in environment variable SCALA_SDK_TEST_VERSION is not one of "
+            + allTestVersions.mkString(", ")
+        )
+      )
+    )
+  }
+}

--- a/src/test/scala/intellij/testfixtures/ScalaVersion.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaVersion.scala
@@ -1,0 +1,63 @@
+package org.jetbrains.plugins.scala
+
+import org.jetbrains.plugins.scala.project.ScalaLanguageLevel
+
+/**
+ * @author Nikolay.Tropin
+ */
+sealed abstract class ScalaVersion(val languageLevel: ScalaLanguageLevel,
+                                   private val minorSuffix: String) extends Ordered[ScalaVersion] {
+
+  def major: String = languageLevel.getVersion
+
+  def minor: String = major + "." + minorSuffix
+
+  override def compare(that: ScalaVersion): Int = languageLevel.compare(that.languageLevel)
+}
+
+object ScalaVersion {
+  val allScalaVersions: Seq[ScalaVersion] = Seq(
+    Scala_2_9,
+    Scala_2_10,
+    Scala_2_11,
+    Scala_2_12,
+    Scala_2_13,
+    Scala_3_0
+  )
+
+  def default: ScalaVersion =
+    allScalaVersions.find(_.languageLevel == ScalaLanguageLevel.getDefault).get
+
+  def fromString(versionString: String): Option[ScalaVersion] =
+    ScalaVersion.allScalaVersions.find(_.toString == versionString)
+}
+
+case object Scala_2_9 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_2_9,
+  "3"
+)
+
+case object Scala_2_10 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_2_10,
+  "7"
+)
+
+case object Scala_2_11 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_2_11,
+  "12"
+)
+
+case object Scala_2_12 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_2_12,
+  "3"
+)
+
+case object Scala_2_13 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_2_13,
+  "0"
+)
+
+case object Scala_3_0 extends ScalaVersion(
+  ScalaLanguageLevel.Scala_3_0,
+  "0-RC1"
+)

--- a/src/test/scala/intellij/testfixtures/SmartJDKLoader.scala
+++ b/src/test/scala/intellij/testfixtures/SmartJDKLoader.scala
@@ -1,0 +1,127 @@
+package org.jetbrains.plugins.scala
+package base
+package libraryLoaders
+
+import java.io.File
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.projectRoots.impl.JavaAwareProjectJdkTableImpl
+import com.intellij.openapi.projectRoots.{JavaSdk, JavaSdkVersion, Sdk}
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.IdeaTestUtil
+import org.jetbrains.plugins.scala.extensions.inWriteAction
+import org.junit.Assert
+
+case class InternalJDKLoader() extends SmartJDKLoader() {
+  override protected def createSdkInstance(): Sdk = JavaAwareProjectJdkTableImpl.getInstanceEx.getInternalJdk
+}
+
+/**
+ * Consider using this instead of HeavyJDKLoader if you don't need java interop in your tests
+ */
+case class MockJDKLoader(jdkVersion: JavaSdkVersion = JavaSdkVersion.JDK_1_8) extends SmartJDKLoader(jdkVersion) {
+  override protected def createSdkInstance(): Sdk = jdkVersion match {
+    case JavaSdkVersion.JDK_1_9 => IdeaTestUtil.getMockJdk9
+    case JavaSdkVersion.JDK_1_8 => IdeaTestUtil.getMockJdk18
+    case JavaSdkVersion.JDK_1_7 => IdeaTestUtil.getMockJdk17
+    case _ => Assert.fail(s"mock JDK version $jdkVersion is unavailable in IDEA test platform"); null
+  }
+}
+
+case class HeavyJDKLoader(jdkVersion: JavaSdkVersion = JavaSdkVersion.JDK_1_8) extends SmartJDKLoader(jdkVersion) {
+  override protected def createSdkInstance(): Sdk = SmartJDKLoader.getOrCreateJDK(jdkVersion)
+}
+
+abstract class SmartJDKLoader(jdkVersion: JavaSdkVersion = JavaSdkVersion.JDK_1_8) extends LibraryLoader {
+  override def init(implicit module: Module, version: ScalaVersion): Unit = {
+    ModuleRootModificationUtil.setModuleSdk(module, createSdkInstance())
+  }
+
+  override def clean(implicit module: Module): Unit = {
+    ModuleRootModificationUtil.setModuleSdk(module, null)
+    val jdkTable = JavaAwareProjectJdkTableImpl.getInstanceEx
+    val allJdks = jdkTable.getAllJdks
+    inWriteAction { allJdks.foreach(jdkTable.removeJdk) }
+  }
+
+  protected def createSdkInstance(): Sdk
+}
+
+object SmartJDKLoader {
+
+  private val candidates = Seq(
+    "/usr/lib/jvm",                     // linux style
+    "C:\\Program Files\\Java\\",        // windows style
+    "C:\\Program Files (x86)\\Java\\",  // windows 32bit style
+    "/Library/Java/JavaVirtualMachines" // mac style
+  )
+
+  def getOrCreateJDK(jdkVersion: JavaSdkVersion = JavaSdkVersion.JDK_1_8): Sdk = {
+    val jdkTable = JavaAwareProjectJdkTableImpl.getInstanceEx
+    val jdkName = jdkVersion.getDescription
+    Option(jdkTable.findJdk(jdkName)).getOrElse {
+      val pathOption = SmartJDKLoader.discoverJDK(jdkVersion)
+      Assert.assertTrue(s"Couldn't find $jdkVersion", pathOption.isDefined)
+      VfsRootAccess.allowRootAccess(pathOption.get)
+      val jdk = JavaSdk.getInstance.createJdk(jdkName, pathOption.get, false)
+      inWriteAction { jdkTable.addJdk(jdk) }
+      jdk
+    }
+  }
+
+  private def discoverJDK(jdkVersion: JavaSdkVersion): Option[String] = discoverJre(candidates, jdkVersion).map(new File(_).getParent)
+
+  private def discoverJre(paths: Seq[String], jdkVersion: JavaSdkVersion): Option[String] = {
+    import java.io._
+
+    val versionMajor = jdkVersion.toString.last.toString
+
+    def isJDK(f: File) = f.listFiles().exists { b =>
+      b.getName == "bin" && b.listFiles().exists(x => x.getName == "javac.exe" || x.getName == "javac")
+    }
+    def inJvm(path: String, suffix: String) = {
+      val postfix = if (path.startsWith("/Library")) "/Contents/Home" else ""  // mac workaround
+      Option(new File(path))
+        .filter(_.exists())
+        .flatMap(_.listFiles()
+          .sortBy(_.getName) // TODO somehow sort by release number to get the newest actually
+          .reverse
+          .find(f => f.getName.contains(suffix) && isJDK(new File(f, postfix)))
+          .map(new File(_, s"$postfix/jre").getAbsolutePath)
+        )
+    }
+    def currentJava() = {
+      sys.props.get("java.version") match {
+        case Some(v) if v.startsWith(s"1.$versionMajor") =>
+          sys.props.get("java.home") match {
+            case Some(path) if isJDK(new File(path).getParentFile) =>
+              Some(path)
+            case _ => None
+          }
+        case _ => None
+      }
+    }
+    val versionStrings = Seq(s"1.$versionMajor", s"-$versionMajor")
+    val priorityPaths = Seq(
+      currentJava(),
+      Option(sys.env.getOrElse(s"JDK_1${versionMajor}_x64",
+        sys.env.getOrElse(s"JDK_1$versionMajor", null))
+      ).map(_+"/jre")  // teamcity style
+    )
+    if (priorityPaths.exists(_.isDefined)) {
+      priorityPaths.flatten.headOption
+    } else {
+      val fullSearchPaths = paths flatMap { p => versionStrings.map((p, _)) }
+      for ((path, ver) <- fullSearchPaths) {
+        inJvm(path, ver) match {
+          case x@Some(p) => return x
+          case _ => None
+        }
+      }
+      None
+    }
+  }
+}
+
+

--- a/src/test/scala/intellij/testfixtures/TestFixtureProvider.scala
+++ b/src/test/scala/intellij/testfixtures/TestFixtureProvider.scala
@@ -1,0 +1,14 @@
+package org.jetbrains.plugins.scala
+
+import com.intellij.openapi.module.Module
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+
+/**
+ * @author mucianm
+ * @since 07.04.16.
+ */
+trait TestFixtureProvider {
+  def getFixture: CodeInsightTestFixture
+
+  //  implicit final def module: Module = getFixture.getModule
+}

--- a/src/test/scala/intellij/testfixtures/TestUtils.java
+++ b/src/test/scala/intellij/testfixtures/TestUtils.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2000-2008 JetBrains s.r.o.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.plugins.scala.util;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.testFramework.ThreadTracker;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.plugins.scala.Console;
+import org.junit.Assert;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by IntelliJ IDEA.
+ * User: Ilya.Sergey
+ */
+public class TestUtils {
+    private static final Logger LOG = Logger.getInstance("org.jetbrains.plugins.scala.util.TestUtils");
+
+    public static final String BEGIN_MARKER = "<begin>";
+    public static final String END_MARKER = "<end>";
+
+    private static String TEST_DATA_PATH = null;
+
+    @NotNull
+    public static String getTestDataPath() {
+        if (TEST_DATA_PATH == null) {
+            try {
+                URL resource = TestUtils.class.getClassLoader().getResource("testdata");
+                TEST_DATA_PATH = resource == null ?
+                        find("scala/scala-impl", "testdata").getAbsolutePath() :
+                        new File(resource.toURI()).getPath().replace(File.separatorChar, '/');
+            } catch (URISyntaxException | IOException e) {
+                LOG.error(e);
+                throw new RuntimeException(e);
+                // just rethrowing here because that's a clearer way to make tests fail than some NPE somewhere else
+            }
+        }
+
+        return TEST_DATA_PATH;
+    }
+
+    @NotNull
+    public static String findTestDataDir(String pathname) throws IOException {
+        return findTestDataDir(new File(pathname), "testdata");
+    }
+
+    private static File find(String pathname, String child) throws IOException {
+        File file = new File("community/" + pathname, child);
+        return file.exists() ? file : new File(findTestDataDir(pathname));
+    }
+
+    /** Go upwards to find testdata, because when running test from IDEA, the launching dir might be some subdirectory. */
+    @NotNull
+    private static String findTestDataDir(File parent, String child) throws IOException {
+        File testData = new File(parent, child).getCanonicalFile();
+
+        if (testData.exists()) {
+            return testData.getCanonicalPath();
+        } else {
+            File newParent = parent.getParentFile();
+            if (newParent == null) throw new RuntimeException("no testdata directory found");
+            else return findTestDataDir(newParent, child);
+        }
+    }
+
+    public static String removeBeginMarker(String text) {
+        int index = text.indexOf(BEGIN_MARKER);
+        return text.substring(0, index) + text.substring(index + BEGIN_MARKER.length());
+    }
+
+    public static String removeEndMarker(String text) {
+        int index = text.indexOf(END_MARKER);
+        return text.substring(0, index) + text.substring(index + END_MARKER.length());
+    }
+
+    private static final long ETALON_TIMING = 438;
+
+    private static final boolean COVERAGE_ENABLED_BUILD = "true".equals(System.getProperty("idea.coverage.enabled.build"));
+
+    private static void assertTiming(String message, long expected, long actual) {
+        if (COVERAGE_ENABLED_BUILD) return;
+        long expectedOnMyMachine = expected * Timings.MACHINE_TIMING / ETALON_TIMING;
+        final double acceptableChangeFactor = 1.1;
+
+        // Allow 10% more in case of test machine is busy.
+        // For faster machines (expectedOnMyMachine < expected) allow nonlinear performance rating:
+        // just perform better than acceptable expected
+        if (actual > expectedOnMyMachine * acceptableChangeFactor &&
+                (expectedOnMyMachine > expected || actual > expected * acceptableChangeFactor)) {
+            int percentage = (int)(((float)100 * (actual - expectedOnMyMachine)) / expectedOnMyMachine);
+            Assert.fail(message + ". Operation took " + percentage + "% longer than expected. Expected on my machine: " + expectedOnMyMachine +
+                    ". Actual: " + actual + ". Expected on Etalon machine: " + expected + "; Actual on Etalon: " +
+                    (actual * ETALON_TIMING / Timings.MACHINE_TIMING));
+        }
+        else {
+            int percentage = (int)(((float)100 * (actual - expectedOnMyMachine)) / expectedOnMyMachine);
+            Console.println(message + ". Operation took " + percentage + "% longer than expected. Expected on my machine: " +
+                    expectedOnMyMachine + ". Actual: " + actual + ". Expected on Etalon machine: " + expected +
+                    "; Actual on Etalon: " + (actual * ETALON_TIMING / Timings.MACHINE_TIMING));
+        }
+    }
+
+    public static void assertTiming(String message, long expected, @NotNull Runnable actionToMeasure) {
+        assertTiming(message, expected, 4, actionToMeasure);
+    }
+
+    private static void assertTiming(String message, long expected, int attempts, @NotNull Runnable actionToMeasure) {
+        while (true) {
+            attempts--;
+            long start = System.currentTimeMillis();
+            actionToMeasure.run();
+            long finish = System.currentTimeMillis();
+            try {
+                assertTiming(message, expected, finish - start);
+                break;
+            }
+            catch (AssertionError e) {
+                if (attempts == 0) throw e;
+                System.gc();
+                System.gc();
+                System.gc();
+            }
+        }
+    }
+
+    public static List<String> readInput(String filePath) throws IOException {
+        String content = new String(FileUtil.loadFileText(new File(filePath)));
+        Assert.assertNotNull(content);
+
+        List<String> input = new ArrayList<>();
+
+        int separatorIndex;
+        content = StringUtil.replace(content, "\r", ""); // for MACs
+
+        // Adding input  before -----
+        while ((separatorIndex = content.indexOf("-----")) >= 0) {
+            input.add(content.substring(0, separatorIndex - 1));
+            content = content.substring(separatorIndex);
+            while (StringUtil.startsWithChar(content, '-')) {
+                content = content.substring(1);
+            }
+            if (StringUtil.startsWithChar(content, '\n')) {
+                content = content.substring(1);
+            }
+        }
+        // Result - after -----
+        if (content.endsWith("\n")) {
+            content = content.substring(0, content.length() - 1);
+        }
+        input.add(content);
+
+        Assert.assertTrue("No data found in source file", input.size() > 0);
+
+        return input;
+    }
+
+
+    public static void disableTimerThread() {
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "Timer");
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "BaseDataReader");
+        ThreadTracker.longRunningThreadCreated(ApplicationManager.getApplication(), "ProcessWaitFor");
+    }
+}

--- a/src/test/scala/intellij/testfixtures/Timings.java
+++ b/src/test/scala/intellij/testfixtures/Timings.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2000-2005 by JetBrains s.r.o. All Rights Reserved.
+ * Use is subject to license terms.
+ */
+package org.jetbrains.plugins.scala.util;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * @author peter
+ */
+public class Timings {
+
+    static {
+        long start = System.currentTimeMillis();
+        BigInteger k = new BigInteger("1");
+        for (int i = 0; i < 1000000; i++) {
+            k = k.add(new BigInteger("1"));
+        }
+        for (int i = 0; i < 15; i++) {
+            try {
+                final File tempFile = File.createTempFile("test", "test" + i);
+                final FileWriter writer = new FileWriter(tempFile);
+                for (int j = 0; j < 15; j++) {
+                    writer.write("test" + j);
+                    writer.flush();
+                }
+                writer.close();
+                final FileReader reader = new FileReader(tempFile);
+                while (reader.read() >= 0) {}
+                reader.close();
+                tempFile.delete();
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        MACHINE_TIMING = System.currentTimeMillis() - start;
+    }
+
+    public static final long MACHINE_TIMING;
+
+
+}

--- a/src/test/scala/intellij/testfixtures/package.scala
+++ b/src/test/scala/intellij/testfixtures/package.scala
@@ -1,0 +1,17 @@
+package intellij
+
+import org.jetbrains.plugins.scala.DependencyManagerBase.DependencyDescription
+import org.jetbrains.plugins.scala.ScalaVersion
+
+package object testfixtures {
+  implicit class RichStr(private val org: String) extends AnyVal {
+
+    def %(artId: String) = DependencyDescription(org, artId, "")
+
+    def %%(artId: String)(implicit scalaVersion: ScalaVersion) = DependencyDescription(
+      org,
+      artId + "_" + scalaVersion.major,
+      ""
+    )
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
@@ -1,0 +1,30 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifyAsInspection
+
+abstract class AsInspectionTest(s: String) extends ZInspectionTest[SimplifyAsInspection] {
+  override protected val hint = s"Replace with $s"
+}
+
+class SimplifyAsTest extends AsInspectionTest(".as") {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  def test_map_to_x(): Unit = {
+    z(s"ZIO.succeed(42).${START}map(_ => x)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).map(_ => x)")
+    val result = z("ZIO.succeed(42).as(x)")
+    testQuickFix(text, result, hint)
+  }
+}
+
+class SimplifyAsErrorTest extends AsInspectionTest(".asError") {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  def test_mapError_to_x(): Unit = {
+    z(s"ZIO.succeed(42).${START}mapError(_ => x)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).mapError(_ => x)")
+    val result = z("ZIO.succeed(42).asError(x)")
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
@@ -1,0 +1,66 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifyBimapInspection
+
+class SimplifyBimapInspectionTest extends ZInspectionTest[SimplifyBimapInspection] {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val hint = "Replace with .bimap"
+
+  def test_map_mapError(): Unit = {
+    z(s"ZIO.succeed(42).${START}map(a).mapError(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).map(a).mapError(b)")
+    val result = z("ZIO.succeed(42).bimap(b, a)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_map_asError(): Unit = {
+    z(s"ZIO.succeed(42).${START}map(a).asError(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).map(a).asError(b)")
+    val result = z("ZIO.succeed(42).bimap(b, a)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_as_mapError(): Unit = {
+    z(s"ZIO.succeed(42).${START}as(a).mapError(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).as(a).mapError(b)")
+    val result = z("ZIO.succeed(42).bimap(b, a)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_as_asError(): Unit = {
+    z(s"ZIO.succeed(42).${START}as(a).asError(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).as(a).asError(b)")
+    val result = z("ZIO.succeed(42).bimap(b, a)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_mapError_map(): Unit = {
+    z(s"ZIO.succeed(42).${START}mapError(a).map(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).mapError(a).map(b)")
+    val result = z("ZIO.succeed(42).bimap(a, b)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_mapError_as(): Unit = {
+    z(s"ZIO.succeed(42).${START}mapError(a).as(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).mapError(a).as(b)")
+    val result = z("ZIO.succeed(42).bimap(a, b)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_asError_map(): Unit = {
+    z(s"ZIO.succeed(42).${START}asError(a).map(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).asError(a).map(b)")
+    val result = z("ZIO.succeed(42).bimap(a, b)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_asError_as(): Unit = {
+    z(s"ZIO.succeed(42).${START}asError(a).as(b)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).asError(a).as(b)")
+    val result = z("ZIO.succeed(42).bimap(a, b)")
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyIgnoreInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyIgnoreInspectionTest.scala
@@ -1,0 +1,31 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifyIgnoreInspection
+
+class SimplifyIgnoreInspectionTest extends ZInspectionTest[SimplifyIgnoreInspection] {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val hint = "Replace with .ignore"
+
+  def test_catchAll_ZIOUnit(): Unit = {
+    z(s"ZIO.succeed(42).${START}catchAll(_ => ZIO.unit)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).catchAll(_ => ZIO.unit)")
+    val result = z("ZIO.succeed(42).ignore")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_foldCause_unit(): Unit = {
+    z(s"ZIO.succeed(42).${START}foldCause(_ => (), _ => ())$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).foldCause(_ => (), _ => ())")
+    val result = z("ZIO.succeed(42).ignore")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_foldCauseM_ZIOUnit(): Unit = {
+    z(s"ZIO.succeed(42).${START}foldCauseM(_ => ZIO.unit, _ => ZIO.unit)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).foldCauseM(_ => ZIO.unit, _ => ZIO.unit)")
+    val result = z("ZIO.succeed(42).ignore")
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
@@ -1,0 +1,30 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifySucceedOptionInspection
+
+abstract class SimplifyOptionInspectionTest(s: String) extends ZInspectionTest[SimplifySucceedOptionInspection] {
+  override protected val hint = s"Replace with $s"
+}
+
+class SucceedNoneInspectionTest extends SimplifyOptionInspectionTest("ZIO.none") {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  def test_succeed_None(): Unit = {
+    z(s"${START}ZIO.succeed(None)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(None)")
+    val result = z("ZIO.none")
+    testQuickFix(text, result, hint)
+  }
+}
+
+class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some") {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  def test_succeed_Some(): Unit = {
+    z(s"${START}ZIO.succeed(Some(a))$END").assertHighlighted()
+    val text   = z("ZIO.succeed(Some(a))")
+    val result = z("ZIO.some(a)")
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
@@ -1,0 +1,23 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG, SELECTION_START_TAG}
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import zio.intellij.inspections.simplifications.SimplifyUnitInspection
+
+class SimplifyUnitInspectionTest extends OperationsOnCollectionInspectionTest {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val classOfInspection: Class[_ <: OperationOnCollectionInspection] =
+    classOf[SimplifyUnitInspection]
+
+  override protected val hint = "Replace with .unit"
+
+  def test_1() {
+    val selected = s"ZIO.succeed(42) $START*> ZIO.unit$END"
+    checkTextHasError(selected)
+    val text = "ZIO.succeed(42) *> ZIO.unit"
+    val result = "ZIO.succeed(42).unit"
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
@@ -1,23 +1,38 @@
 package zio.inspections
 
 import com.intellij.testFramework.EditorTestUtil
-import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG, SELECTION_START_TAG}
-import org.jetbrains.plugins.scala.codeInspection.collections._
 import zio.intellij.inspections.simplifications.SimplifyUnitInspection
 
-class SimplifyUnitInspectionTest extends OperationsOnCollectionInspectionTest {
+class SimplifyUnitInspectionTest extends ZInspectionTest[SimplifyUnitInspection] {
   import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
-
-  override protected val classOfInspection: Class[_ <: OperationOnCollectionInspection] =
-    classOf[SimplifyUnitInspection]
 
   override protected val hint = "Replace with .unit"
 
-  def test_1() {
-    val selected = s"ZIO.succeed(42) $START*> ZIO.unit$END"
-    checkTextHasError(selected)
-    val text = "ZIO.succeed(42) *> ZIO.unit"
-    val result = "ZIO.succeed(42).unit"
+  def test_zipRight_method(): Unit = {
+    z(s"ZIO.succeed(42).$START*>(ZIO.unit)$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).*>(ZIO.unit)")
+    val result = z("ZIO.succeed(42).unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_zipRight_infix(): Unit = {
+    z(s"ZIO.succeed(42) $START*> ZIO.unit$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42) *> ZIO.unit")
+    val result = z("ZIO.succeed(42).unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_as_unit(): Unit = {
+    z(s"ZIO.succeed(42).${START}as(())$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).as(())")
+    val result = z("ZIO.succeed(42).unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_map_to_unit(): Unit = {
+    z(s"ZIO.succeed(42).${START}map(_ => ())$END").assertHighlighted()
+    val text   = z("ZIO.succeed(42).map(_ => ())")
+    val result = z("ZIO.succeed(42).unit")
     testQuickFix(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyWhenInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyWhenInspectionTest.scala
@@ -1,0 +1,37 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifyWhenInspection
+
+class SimplifyWhenInspectionTest extends ZInspectionTest[SimplifyWhenInspection] {
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val hint = "Replace with .when"
+
+  def test_when_reference_to_val(): Unit = {
+    z(s"""|val a = true
+          |val b = ZIO.succeed(42)
+          |${START}if (a) b else ZIO.unit$END""".stripMargin).assertHighlighted()
+    val text   = z(
+      s"""|val a = true
+          |val b = ZIO.succeed(42)
+          |if (a) b else ZIO.unit""".stripMargin)
+    val result = z(
+      s"""|val a = true
+          |val b = ZIO.succeed(42)
+          |b.when(a)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_when_direct_reference(): Unit = {
+    z(s"""|val a = true
+          |${START}if (a) ZIO.succeed(42) else ZIO.unit$END""".stripMargin).assertHighlighted()
+    val text   = z(
+      s"""|val a = true
+          |if (a) ZIO.succeed(42) else ZIO.unit""".stripMargin)
+    val result = z(
+      s"""|val a = true
+          |ZIO.succeed(42).when(a)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/ZInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZInspectionTest.scala
@@ -18,7 +18,9 @@ abstract class ZInspectionTest[T <: ZInspection: ClassTag] extends OperationsOnC
   def z(s: String): String =
     s"""import zio._
        |object Test {
-       |  val _ = $s
+       |  def foo = {
+       |   $s
+       | }
        |}
        |""".stripMargin
 

--- a/src/test/scala/zio/inspections/ZInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZInspectionTest.scala
@@ -1,0 +1,28 @@
+package zio.inspections
+
+import intellij.testfixtures._
+import org.jetbrains.plugins.scala.base.libraryLoaders._
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import zio.intellij.inspections.ZInspection
+
+import scala.reflect._
+
+abstract class ZInspectionTest[T <: ZInspection: ClassTag] extends OperationsOnCollectionInspectionTest {
+  final override protected val classOfInspection = classTag[T].runtimeClass.asInstanceOf[Class[_ <: ZInspection]]
+
+  override protected def librariesLoaders: Seq[LibraryLoader] =
+    IvyManagedLoader(
+      "dev.zio" %% "zio" % "1.0.0-RC16"
+    ) :: Nil
+
+  def z(s: String): String =
+    s"""import zio._
+       |object Test {
+       |  val _ = $s
+       |}
+       |""".stripMargin
+
+  protected implicit class S(s: String) {
+    def assertHighlighted(): Unit = checkTextHasError(s)
+  }
+}

--- a/src/test/scala/zio/inspections/ZInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZInspectionTest.scala
@@ -18,7 +18,6 @@ abstract class ZInspectionTest[T <: ZInspection: ClassTag] extends OperationsOnC
 
   def z(s: String): String =
     s"""import zio._
-       |import scala._
        |object Test {
        |  def foo = {
        |   $s

--- a/src/test/scala/zio/inspections/ZInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZInspectionTest.scala
@@ -11,12 +11,14 @@ abstract class ZInspectionTest[T <: ZInspection: ClassTag] extends OperationsOnC
   final override protected val classOfInspection = classTag[T].runtimeClass.asInstanceOf[Class[_ <: ZInspection]]
 
   override protected def librariesLoaders: Seq[LibraryLoader] =
-    IvyManagedLoader(
-      "dev.zio" %% "zio" % "1.0.0-RC16"
-    ) :: Nil
+    super.librariesLoaders :+
+      IvyManagedLoader(
+        "dev.zio" %% "zio" % "1.0.0-RC16"
+      )
 
   def z(s: String): String =
     s"""import zio._
+       |import scala._
        |object Test {
        |  def foo = {
        |   $s


### PR DESCRIPTION
This fixes #19. I've copied some base classes from the IntelliJ scala plugin, because test classes aren't published (yet), so they can't be referenced from gradle.
Once JetBrains publishes those test artifacts (they said they're working on it), they can be removed. Meanwhile, it's now possible to write tests for inspections, maybe other types of fixes!