### PR TITLE
Adding a quickfix to assist migrating from the deprecated uncurried 'assert'

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,9 +72,16 @@
         <localInspection implementationClass="zio.intellij.inspections.deprecations.DeprecatedTraverseInspection"
                          displayName="Replace deprecated traverse methods with foreach"
                          groupPath="Scala,ZIO"
-                         groupName="Simplifications"
-                         shortName="DeprecatedTraverseInspection" level="WEAK WARNING"
+                         groupName="Migrations"
+                         shortName="DeprecatedTraverseInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="zio.intellij.inspections.deprecations.DeprecatedAssertInspection"
+                         displayName="Replace deprecated assert methods with new syntax"
+                         groupPath="Scala,ZIO"
+                         groupName="Migrations"
+                         shortName="DeprecatedAssertInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>
@@ -84,7 +91,7 @@
             <category>ZIO/Migrations</category>
             <className>zio.intellij.intentions.migrations.MigrateTestSuiteToSpecField</className>
         </intentionAction>
-
+        
         <!-- test runner -->
         <configurationType implementation="zio.intellij.testsupport.ZTestConfigurationType"/>
         <runConfigurationProducer implementation="zio.intellij.testsupport.ZTestRunConfigurationProducer"/>

--- a/src/main/resources/inspectionDescriptions/DeprecatedAssertInspection.html
+++ b/src/main/resources/inspectionDescriptions/DeprecatedAssertInspection.html
@@ -1,0 +1,8 @@
+<html>
+<body>Converts the assertion expression to the curried version, improving type inference.<br/>
+The uncurried <code>assert</code> is deprecated.
+<pre>
+assert(value, assertion) -> assert(value)(assertion)
+</pre>
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/deprecations/DeprecatedAssertInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/deprecations/DeprecatedAssertInspection.scala
@@ -1,0 +1,27 @@
+package zio.intellij.inspections.deprecations
+
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import org.jetbrains.plugins.scala.extensions.&&
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+import zio.intellij.inspections._
+import zio.intellij.inspections.zioMethods._
+
+class DeprecatedAssertInspection extends ZInspection(DeprecatedAssertRefactoringType)
+
+object DeprecatedAssertRefactoringType extends SimplificationType {
+  val ProblemText = "assert(value)(assertion)"
+
+  override def hint: String = "Replace with assert(value)(assertion)"
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] = {
+    def replacement(a: ScExpression, b: ScExpression) =
+      replace(expr)
+        .withText(s"assert(${a.getText})(${b.getText})")
+        .highlightFrom(expr)
+
+    expr match {
+      case `assert`(a, b) && IsDeprecated(ann) if ann.getText.contains(ProblemText) => Some(replacement(a, b))
+      case _                                                                        => None
+    }
+  }
+}

--- a/src/main/scala/zio/intellij/inspections/zioMethods/package.scala
+++ b/src/main/scala/zio/intellij/inspections/zioMethods/package.scala
@@ -9,4 +9,6 @@ package object zioMethods {
   private[inspections] val `.catchAll`   = invocation("catchAll").from(zioClasses)
   private[inspections] val `.foldCause`  = invocation("foldCause").from(zioClasses)
   private[inspections] val `.foldCauseM` = invocation("foldCauseM").from(zioClasses)
+
+  private[inspections] val `assert` = unqualified("assert").from(zioClasses)
 }

--- a/src/main/scala/zio/intellij/intentions/ZElementAnnotationIntention.scala
+++ b/src/main/scala/zio/intellij/intentions/ZElementAnnotationIntention.scala
@@ -1,0 +1,35 @@
+package zio.intellij.intentions
+
+import com.intellij.codeInsight.daemon.impl.AnnotationHolderImpl
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
+import com.intellij.lang.annotation.{Annotation, AnnotationSession}
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.{PsiDocumentManager, PsiElement}
+import org.jetbrains.plugins.scala.annotator.element.ElementAnnotator
+import org.jetbrains.plugins.scala.lang.psi.api.ScalaPsiElement
+import scala.reflect._
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
+abstract class ZElementAnnotationIntention[T <: ScalaPsiElement: ClassTag] extends PsiElementBaseIntentionAction with ZIcon {
+  override def getText: String = getFamilyName
+
+  protected def problemAnnotations(
+    element: PsiElement,
+    project: Project,
+    editor: Editor
+  ): Option[(T, List[Annotation])] = {
+    def annotationsFor(elem: T): List[Annotation] = {
+      val file   = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument)
+      val holder = new AnnotationHolderImpl(new AnnotationSession(file))
+      ElementAnnotator.annotate(elem, typeAware = true)(holder)
+      holder.asScala.toList
+    }
+
+    Option(PsiTreeUtil.getParentOfType(element, classTag[T].runtimeClass.asInstanceOf[Class[T]]))
+      .map(elem => (elem, annotationsFor(elem)))
+  }
+
+}

--- a/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
+++ b/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
@@ -1,8 +1,6 @@
 package zio.intellij.intentions
 
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.util.Iconable
-import javax.swing.Icon
 import org.jetbrains.plugins.scala.codeInsight.intention.types._
 import org.jetbrains.plugins.scala.codeInspection.collections.isOfClassFrom
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
@@ -11,7 +9,7 @@ import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import zio.intellij.inspections.zioClasses
 
 
-abstract class ZTypeAnnotationIntention extends AbstractTypeAnnotationIntention with Iconable {
+abstract class ZTypeAnnotationIntention extends AbstractTypeAnnotationIntention with ZIcon {
   final override def getText: String = getFamilyName
 
   override protected def descriptionStrategy: Strategy = ZStrategy {
@@ -23,8 +21,6 @@ abstract class ZTypeAnnotationIntention extends AbstractTypeAnnotationIntention 
     case (te, declaredType) if maybeEditor.isDefined => invoke(te, declaredType, maybeEditor.get)
     case _                                           => false
   }
-
-  override def getIcon(flags: Int): Icon = zio.intellij.ZioIcon
 
   protected def invoke(te: ScTypeElement, declaredType: ScType, editor: Editor): Boolean
 }

--- a/src/main/scala/zio/intellij/intentions/package.scala
+++ b/src/main/scala/zio/intellij/intentions/package.scala
@@ -1,0 +1,10 @@
+package zio.intellij
+
+import com.intellij.openapi.util.Iconable
+import javax.swing.Icon
+
+package object intentions {
+  trait ZIcon extends Iconable {
+    override def getIcon(flags: Int): Icon = zio.intellij.ZioIcon
+  }
+}


### PR DESCRIPTION
In ZIO RC18+, the non-curried `assert` is deprecated.
This PR adds a quickfix to change it to the curried form. As with most quickfixes, it can be applied to the entire module!

![image](https://user-images.githubusercontent.com/601206/75121120-c8f97c80-5699-11ea-9759-5ac66f423b98.png)
