### PR TITLE
[WIP] fix @accessible generation

### DIFF
--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
@@ -1,11 +1,11 @@
 package zio.intellij.synthetic.macros
 
-import org.jetbrains.plugins.scala.lang.psi.api.base.ScAnnotation
+import org.jetbrains.plugins.scala.lang.psi.api.base.{ ScAnnotation, ScFieldId }
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDeclaration
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ ScObject, ScTypeDefinition }
 import org.jetbrains.plugins.scala.lang.psi.impl.base.ScLiteralImpl
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
-import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
+import org.jetbrains.plugins.scala.lang.psi.types.{ PhysicalMethodSignature, TermSignature }
 
 class ModulePatternAccessible extends SyntheticMembersInjector {
 
@@ -16,32 +16,64 @@ class ModulePatternAccessible extends SyntheticMembersInjector {
 
   private def helperObjectExtension(annotation: ScAnnotation, sco: ScObject): Seq[String] =
     annotationFirstParam(annotation)
-      .map(name => s"def $name : ${sco.qualifiedName}.Service[${sco.qualifiedName}] = ???")
+      .map(name => s"object $name { ${helperObjectBody(sco)} }")
       .toSeq
 
-  private def accessorTraitExtension(sco: ScObject): String = {
+  private def helperObjectBody(sco: ScObject): String = {
     val serviceTrait = sco.typeDefinitions.find(_.name == "Service")
-    val signatures = serviceTrait.toSeq.flatMap(_.allMethods).collect {
-      case PhysicalMethodSignature(method: ScFunctionDeclaration, _) => s"${method.getText} = ???"
+    val methods      = serviceTrait.toSeq.flatMap(td => td.allMethods ++ td.allVals)
+
+    object Field {
+      def unapply(ts: TermSignature): Option[ScFieldId] =
+        Some(ts.namedElement).collect {
+          case fid: ScFieldId => fid
+        }
     }
 
-    s"""trait Accessors extends ${sco.qualifiedName}.Service[${sco.name}] {" +
-           ${signatures.mkString("\n")}
-        }"""
+    val signatures = methods.collect {
+      case Field(fid) =>
+        s"val ${fid.name} = zio.ZIO.access[zio.Has[${sco.qualifiedName}.Service]](_.get).flatMap(_.${fid.name})"
+      case PhysicalMethodSignature(method: ScFunctionDeclaration, _) =>
+        val name       = method.name
+        val typeParams = method.typeParametersClause.map(_.getText).getOrElse("")
+        val params     = method.paramClauses.getText
+        val typeParameterApplication =
+          method.typeParametersClause
+            .map { tps =>
+              tps.typeParameters
+                .map(tp => tp.name)
+                .mkString("[", ", ", "]")
+            }
+            .getOrElse("")
+        val parameterApplication =
+          method.paramClauses.clauses
+            .map { clause =>
+              clause.parameters
+                .map { parameter =>
+                  if (parameter.isVarArgs()) s"${parameter.name}: _*"
+                  else parameter.name
+                }
+                .mkString("(", ", ", ")")
+            }
+            .mkString("")
+        s"def $name$typeParams$params =" +
+          s" zio.ZIO.access[zio.Has[${sco.qualifiedName}.Service]](_.get)" +
+          s".flatMap(_.$name$typeParameterApplication$parameterApplication)"
+    }
+
+    signatures.mkString("\n")
   }
 
-  private def findAccessibleMacroAnnotation(sco: ScObject): Option[ScAnnotation] = {
-    val companion = sco.fakeCompanionClassOrCompanionClass
-    Option(companion.getAnnotation("zio.macros.annotation.accessible")).collect {
+  private def findAccessibleMacroAnnotation(sco: ScObject): Option[ScAnnotation] =
+    Option(sco.getAnnotation("zio.macros.annotation.accessible")).collect {
       case a: ScAnnotation => a
     }
-  }
 
   override def injectMembers(source: ScTypeDefinition): Seq[String] =
     source match {
       case sco: ScObject =>
         val annotation = findAccessibleMacroAnnotation(sco)
-        annotation.map(a => helperObjectExtension(a, sco) :+ accessorTraitExtension(sco)).getOrElse(Nil)
+        annotation.map(a => helperObjectExtension(a, sco)).getOrElse(Nil)
       case _ =>
         Nil
     }

--- a/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
@@ -4,12 +4,11 @@ import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.util.PsiTreeUtil
 import intellij.testfixtures._
 import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
-import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
+import org.jetbrains.plugins.scala.base.libraryLoaders.{ IvyManagedLoader, LibraryLoader }
 import org.jetbrains.plugins.scala.lang.macros.SynteticInjectorsTestUtils._
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
-import org.jetbrains.plugins.scala.lang.psi.api.base.{ScAnnotation, ScLiteral}
+import org.jetbrains.plugins.scala.lang.psi.api.base.{ ScAnnotation, ScLiteral }
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
 import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
 import org.junit.Assert._
 
@@ -20,8 +19,8 @@ class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapte
   override def librariesLoaders: Seq[LibraryLoader] =
     super.librariesLoaders :+ IvyManagedLoader("dev.zio" %% "zio-macros-core" % "0.5.0")
 
-  def fromAnnotation(clazz: ScTypeDefinition): Option[String] =
-    clazz.annotations(annotationQual).headOption.flatMap {
+  def fromAnnotation(obj: ScObject): Option[String] =
+    obj.annotations(annotationQual).headOption.flatMap {
       case annotation: ScAnnotation =>
         annotation.annotationExpr.getAnnotationParameters.headOption.map {
           case lit: ScLiteral => lit.getValue().toString
@@ -29,51 +28,84 @@ class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapte
       case _ => None
     }
 
-  def accessor(text: String): ScFunctionDefinition = {
+  def accessor(text: String): ScObject = {
     val cleaned  = StringUtil.convertLineSeparators(text)
     val caretPos = cleaned.indexOf(caret)
     getFixture.configureByText("dummy.scala", cleaned.replace(caret, ""))
 
-    val clazz = PsiTreeUtil.findElementOfClassAtOffset(
+    val obj = PsiTreeUtil.findElementOfClassAtOffset(
       getFile,
       caretPos,
-      classOf[ScTypeDefinition],
+      classOf[ScObject],
       false
     )
 
-    val accessorName = fromAnnotation(clazz)
-      .getOrElse(fail(s"Unable to extract the companion name from the '${annotationQual}' annotation argument"))
+    val accessorName = fromAnnotation(obj)
+      .getOrElse(fail(s"Unable to extract the companion name from the '$annotationQual' annotation argument"))
 
-    val accessorDef = ScalaPsiUtil
-      .getCompanionModule(clazz)
-      .getOrElse(clazz.asInstanceOf[ScObject])
-      .allMethods
+    val accessorDef = obj.allInnerTypeDefinitions
       .collectFirst {
-        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == accessorName => fun
+        case o: ScObject if o.name == accessorName => o
       }
 
     accessorDef
       .getOrElse(
-        fail(s"Accessor definition '$accessorName' was not found inside the companion object of ${clazz.name}")
-          .asInstanceOf[ScFunctionDefinition]
+        fail(s"Accessor definition '$accessorName' was not found inside object ${obj.name}")
+          .asInstanceOf[ScObject]
       )
   }
+
+  def method(obj: ScObject, name: String): ScFunctionDefinition =
+    obj.allMethods
+      .collectFirst {
+        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == name => fun
+      }
+      .getOrElse(
+        fail(s"Method declaration $name was not found inside object ${obj.name}")
+          .asInstanceOf[ScFunctionDefinition]
+      )
 
   def test_generates_accessor_function_in_companion(): Unit = {
     val code =
       s"""
+import zio._
+import zio.blocking.Blocking
 import zio.macros.annotation.accessible
 
 @accessible(">")
-trait E${caret}xample {
-  val example: Example.Service[Any]
-}
+object E${caret}xample {
+  type Environment = Blocking
 
-object Example {
-  trait Service[R] {}
+  type EIO[+T] = ZIO[Environment, Nothing, T]
+
+  trait Service {
+    val v: EIO[Boolean]
+    def m0: EIO[Unit]
+    def m1(s: String): EIO[Int]
+    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
+  }
 }
 """
 
-    accessor(code) mustBeExactly `def`(">", "Example.Service[Example]")
+    val scObject = accessor(code)
+    scObject mustBeExactly `object`(">").copy(functions = Seq(
+      `def`("m0", "Any"),
+      `def`("m1", "_root_.scala.Predef.String => Any"),
+      `def`("m3", "[T] String => ((T, Int)) => Int => Any")
+    )
+    )
+
+    assertEquals(
+      "def m0 = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m0)",
+      method(scObject, "m0").getText
+    )
+    assertEquals(
+      "def m1(s: String) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m1(s))",
+      method(scObject, "m1").getText
+    )
+    assertEquals(
+      """def m3[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m3[T](s2)(p)(i2: _*))""",
+      method(scObject, "m3").getText
+    )
   }
 }


### PR DESCRIPTION
Currently accessor object extends `Service`, which is not correct: there is no `Service` in `Environment`.

This PR adds accessor object generation.
For this annotation usage:
```scala
@accessible(">")
object Example {
  type Environment = Blocking

  type EIO[+T] = ZIO[Environment, Nothing, T]

  trait Service {
    val v: EIO[Boolean]
    def m0: EIO[Unit]
    def m1(s: String): EIO[Int]
    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
  }
}
```
We'll get such result:
```scala
object Example {

  object > {
    val v = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.v)
    def m0 = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m0)
    def m1(s: String) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m1(s))
    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m3[T](s2)(p)(i2: _*))
  }
}
```
Idea is able to get correct result types for type inference.

Unfortunately this PR generates incorrect result types for methods with not-ZIO result types - I have no idea how to check if type is a child type of `ZIO` in plugin.

This PR also updates `@accessible` to `1.0.0-RC18-2` `Has` notation.