### PR TITLE
fix @accessible generation

### DIFF
--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyChainToForInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyChainToForInspection.scala
@@ -56,7 +56,7 @@ object ForToChainSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] =
     expr match {
-      case forExpr: ScFor if forExpr.`type`().exists(fromZio) =>
+      case forExpr: ScFor if forExpr.`type`().exists(fromZioLike) =>
         forExpr.enumerators.flatMap { enumerators =>
           if (enumerators.guards.isEmpty && enumerators.forBindings.isEmpty && enumerators.generators.nonEmpty) {
             forExpr.body match {

--- a/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
+++ b/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
@@ -19,7 +19,7 @@ import org.jetbrains.plugins.scala.lang.psi.types.{AliasType, ScType, TypePresen
 import org.jetbrains.plugins.scala.lang.psi.{ScalaPsiUtil, TypeAdjuster}
 import org.jetbrains.plugins.scala.project.ProjectContext
 import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker.checkIntention
-import zio.intellij.inspections.fromZio
+import zio.intellij.inspections.fromZioLike
 import zio.intellij.intentions.ZTypeAnnotationIntention
 
 // borrowed from MakeTypeMoreSpecificIntention
@@ -51,7 +51,7 @@ final class SuggestTypeAlias extends ZTypeAnnotationIntention {
     adjustElementAtOffset(element, editor) match {
       case element: PsiElement if checkIntention(this, element) =>
         element.parentOfType[ScSimpleTypeElement] match {
-          case Some(tpe) if tpe.`type`().toOption.exists(fromZio) =>
+          case Some(tpe) if tpe.`type`().toOption.exists(fromZioLike) =>
             complete(element, descriptionStrategy)
           case _ => false
         }

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
@@ -1,5 +1,6 @@
 package zio.intellij.synthetic.macros
 
+import org.jetbrains.plugins.scala.lang.psi.PresentationUtil.presentationString
 import org.jetbrains.plugins.scala.lang.psi.api.base.{ScAnnotation, ScFieldId}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDeclaration
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
@@ -26,8 +27,8 @@ class ModulePatternAccessible extends SyntheticMembersInjector {
         s"val ${fid.name} = zio.ZIO.service[${sco.qualifiedName}.Service].$mapOrFlatMap(_.${fid.name})"
       case PhysicalMethodSignature(method: ScFunctionDeclaration, _) =>
         val name       = method.name
-        val typeParams = method.typeParametersClause.map(_.getText).getOrElse("")
-        val params     = method.paramClauses.getText
+        val typeParams = method.typeParametersClause.fold("")(presentationString)
+        val params     = presentationString(method.paramClauses)
         val typeParameterApplication =
           method.typeParametersClause
             .map { tps =>

--- a/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
@@ -5,7 +5,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import intellij.testfixtures._
 import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
 import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
-import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunctionDefinition, ScPatternDefinition}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
 import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
 import org.junit.Assert._
@@ -14,32 +14,15 @@ class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapte
   private val caret = "<caret>"
 
   override def librariesLoaders: Seq[LibraryLoader] =
-    super.librariesLoaders :+ IvyManagedLoader("dev.zio" %% "zio-macros" % "1.0.0-RC20")
+    super.librariesLoaders :+
+      IvyManagedLoader("dev.zio" %% "zio"        % "1.0.0-RC20") :+
+      IvyManagedLoader("dev.zio" %% "zio-macros" % "1.0.0-RC20")
 
-  def extendedObject(text: String): ScObject = {
-    val cleaned  = StringUtil.convertLineSeparators(text)
-    val caretPos = cleaned.indexOf(caret)
-    getFixture.configureByText("dummy.scala", cleaned.replace(caret, ""))
+  private var extendedObject: ScObject = _
 
-    PsiTreeUtil.findElementOfClassAtOffset(
-      getFile,
-      caretPos,
-      classOf[ScObject],
-      false
-    )
-  }
+  override def setUp(): Unit = {
+    super.setUp()
 
-  def method(obj: ScObject, name: String): ScFunctionDefinition =
-    obj.allMethods
-      .collectFirst {
-        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == name => fun
-      }
-      .getOrElse(
-        fail(s"Method declaration $name was not found inside object ${obj.name}")
-          .asInstanceOf[ScFunctionDefinition]
-      )
-
-  def test_generates_accessor_function_in_companion(): Unit = {
     val code =
       s"""
 import zio._
@@ -56,24 +39,87 @@ object E${caret}xample {
     val v: EIO[Boolean]
     def m0: EIO[Unit]
     def m1(s: String): EIO[Int]
-    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
+    def m2[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
+
+    val vNonZIO: Boolean
+    def m0NonZIO: Unit
+    def m1NonZIO(s: String): Int
+    def m2NonZIO[T](s2: String = "")(p: (T, Int))(i2: Int*): Double
   }
 }
 """
+    val cleaned  = StringUtil.convertLineSeparators(code)
+    val caretPos = cleaned.indexOf(caret)
+    configureFromFileText(cleaned.replace(caret, ""))
 
-    val scObject = extendedObject(code)
-
-    assertEquals(
-      "def m0 = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m0)",
-      method(scObject, "m0").getText
-    )
-    assertEquals(
-      "def m1(s: String) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m1(s))",
-      method(scObject, "m1").getText
-    )
-    assertEquals(
-      """def m3[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m3[T](s2)(p)(i2: _*))""",
-      method(scObject, "m3").getText
+    extendedObject = PsiTreeUtil.findElementOfClassAtOffset(
+      getFile,
+      caretPos,
+      classOf[ScObject],
+      false
     )
   }
+
+  private def method(name: String): ScFunctionDefinition =
+    extendedObject.allMethods
+      .collectFirst {
+        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == name => fun
+      }
+      .getOrElse(
+        fail(s"Method declaration $name was not found inside object ${extendedObject.name}")
+          .asInstanceOf[ScFunctionDefinition]
+      )
+
+  private def field(name: String): ScPatternDefinition =
+    extendedObject.membersWithSynthetic
+      .collectFirst {
+        case pd: ScPatternDefinition if pd.isSimple && pd.bindings.head.name == name => pd
+      }
+      .getOrElse(
+        fail(s"Field $name was not found inside object ${extendedObject.name}")
+          .asInstanceOf[ScPatternDefinition]
+      )
+
+  def test_generates_accessor_value_for_ZIO_field(): Unit = assertEquals(
+    "val v = zio.ZIO.service[Example.Service].flatMap(_.v)",
+    field("v").getText
+  )
+
+  def test_generates_accessor_function_for_ZIO_method_without_arguments(): Unit = assertEquals(
+    "def m0 = zio.ZIO.service[Example.Service].flatMap(_.m0)",
+    method("m0").getText
+  )
+
+  def test_generates_accessor_function_for_ZIO_method_with_argument(): Unit = assertEquals(
+    "def m1(s: String) = zio.ZIO.service[Example.Service].flatMap(_.m1(s))",
+    method("m1").getText
+  )
+
+  def test_generates_accessor_function_for_generic_ZIO_method_with_multiple_arg_lists_default_args_and_varargs(): Unit =
+    assertEquals(
+      """def m2[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.service[Example.Service].flatMap(_.m2[T](s2)(p)(i2: _*))""",
+      method("m2").getText
+    )
+
+  def test_generates_accessor_value_for_non_ZIO_field(): Unit = assertEquals(
+    "val vNonZIO = zio.ZIO.service[Example.Service].map(_.vNonZIO)",
+    field("vNonZIO").getText
+  )
+
+  def test_generates_accessor_function_for_non_ZIO_method_without_arguments(): Unit = assertEquals(
+    "def m0NonZIO = zio.ZIO.service[Example.Service].map(_.m0NonZIO)",
+    method("m0NonZIO").getText
+  )
+
+  def test_generates_accessor_function_for_non_ZIO_method_with_argument(): Unit = assertEquals(
+    "def m1NonZIO(s: String) = zio.ZIO.service[Example.Service].map(_.m1NonZIO(s))",
+    method("m1NonZIO").getText
+  )
+
+  def test_generates_accessor_function_for_generic_non_ZIO_method_with_multiple_arg_lists_default_args_and_varargs()
+    : Unit = assertEquals(
+    """def m2NonZIO[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.service[Example.Service].map(_.m2NonZIO[T](s2)(p)(i2: _*))""",
+    method("m2NonZIO").getText
+  )
+
 }

--- a/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
@@ -7,7 +7,8 @@ import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
 import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunctionDefinition, ScPatternDefinition}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
-import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
+import org.jetbrains.plugins.scala.lang.psi.types.{PhysicalMethodSignature, TypePresentationContext}
+import org.jetbrains.plugins.scala.lang.refactoring.ScTypePresentationExt
 import org.junit.Assert._
 
 class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapter {
@@ -15,10 +16,12 @@ class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapte
 
   override def librariesLoaders: Seq[LibraryLoader] =
     super.librariesLoaders :+
-      IvyManagedLoader("dev.zio" %% "zio"        % "1.0.0-RC20") :+
-      IvyManagedLoader("dev.zio" %% "zio-macros" % "1.0.0-RC20")
+      IvyManagedLoader("dev.zio" %% "zio"         % "1.0.0-RC20") :+
+      IvyManagedLoader("dev.zio" %% "zio-streams" % "1.0.0-RC20") :+
+      IvyManagedLoader("dev.zio" %% "zio-macros"  % "1.0.0-RC20")
 
-  private var extendedObject: ScObject = _
+  private var extendedObject: ScObject                                  = _
+  implicit private var typePresentationContext: TypePresentationContext = _
 
   override def setUp(): Unit = {
     super.setUp()
@@ -28,6 +31,7 @@ class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapte
 import zio._
 import zio.blocking.Blocking
 import zio.macros.accessible
+import zio.stream.ZStream
 
 @accessible
 object E${caret}xample {
@@ -35,16 +39,22 @@ object E${caret}xample {
 
   type EIO[+T] = ZIO[Environment, Nothing, T]
 
+  sealed trait Foo { val value: String }
+  final case class Bar(value: String) extends Foo
+  final case class Wrapped[T](value: T)
+
   trait Service {
     val v: EIO[Boolean]
     def m0: EIO[Unit]
     def m1(s: String): EIO[Int]
-    def m2[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
+    def m2[T](s2: String = "")(p: (T, Int))(i2: Int*): UIO[Double]
+    def m3[T <: Foo](t: Wrapped[T]): IO[String, List[T]]
 
     val vNonZIO: Boolean
     def m0NonZIO: Unit
     def m1NonZIO(s: String): Int
     def m2NonZIO[T](s2: String = "")(p: (T, Int))(i2: Int*): Double
+    def stream(n: Int): ZStream[Any, String, Int]
   }
 }
 """
@@ -58,6 +68,7 @@ object E${caret}xample {
       classOf[ScObject],
       false
     )
+    typePresentationContext = TypePresentationContext(extendedObject)
   }
 
   private def method(name: String): ScFunctionDefinition =
@@ -80,46 +91,116 @@ object E${caret}xample {
           .asInstanceOf[ScPatternDefinition]
       )
 
-  def test_generates_accessor_value_for_ZIO_field(): Unit = assertEquals(
-    "val v = zio.ZIO.service[Example.Service].flatMap(_.v)",
-    field("v").getText
-  )
+  def test_generates_accessor_value_for_ZIO_field(): Unit = {
+    assertEquals(
+      "val v = zio.ZIO.service[Example.Service].flatMap(_.v)",
+      field("v").getText
+    )
+    assertEquals(
+      Right("ZIO[Example.Environment with Has[Example.Service], Nothing, Boolean]"),
+      field("v").`type`().map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_function_for_ZIO_method_without_arguments(): Unit = assertEquals(
-    "def m0 = zio.ZIO.service[Example.Service].flatMap(_.m0)",
-    method("m0").getText
-  )
+  def test_generates_accessor_function_for_ZIO_method_without_arguments(): Unit = {
+    assertEquals(
+      "def m0 = zio.ZIO.service[Example.Service].flatMap(_.m0)",
+      method("m0").getText
+    )
+    assertEquals(
+      Right("ZIO[Example.Environment with Has[Example.Service], Nothing, Unit]"),
+      method("m0").`type`().map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_function_for_ZIO_method_with_argument(): Unit = assertEquals(
-    "def m1(s: String) = zio.ZIO.service[Example.Service].flatMap(_.m1(s))",
-    method("m1").getText
-  )
+  def test_generates_accessor_function_for_ZIO_method_with_argument(): Unit = {
+    assertEquals(
+      "def m1(s: String) = zio.ZIO.service[Example.Service].flatMap(_.m1(s))",
+      method("m1").getText
+    )
+    assertEquals(
+      Right("String => ZIO[Example.Environment with Has[Example.Service], Nothing, Int]"),
+      method("m1").`type`().map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_function_for_generic_ZIO_method_with_multiple_arg_lists_default_args_and_varargs(): Unit =
+  def test_generates_accessor_function_for_generic_ZIO_method_with_multiple_arg_lists_default_args_and_varargs()
+    : Unit = {
     assertEquals(
       """def m2[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.service[Example.Service].flatMap(_.m2[T](s2)(p)(i2: _*))""",
       method("m2").getText
     )
+    assertEquals(
+      Right("ZIO[Has[Example.Service], Nothing, Double]"),
+      method("m2").returnType.map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_value_for_non_ZIO_field(): Unit = assertEquals(
-    "val vNonZIO = zio.ZIO.service[Example.Service].map(_.vNonZIO)",
-    field("vNonZIO").getText
-  )
+  def test_generates_accessor_function_for_generic_ZIO_method_with_type_constraints(): Unit = {
+    assertEquals(
+      """def m3[T <: Example.Foo](t: Example.Wrapped[T]) = zio.ZIO.service[Example.Service].flatMap(_.m3[T](t))""",
+      method("m3").getText
+    )
+    assertEquals(
+      Right("Example.Wrapped[T] => ZIO[Has[Example.Service], String, List[T]]"),
+      method("m3").`type`().map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_function_for_non_ZIO_method_without_arguments(): Unit = assertEquals(
-    "def m0NonZIO = zio.ZIO.service[Example.Service].map(_.m0NonZIO)",
-    method("m0NonZIO").getText
-  )
+  def test_generates_accessor_value_for_non_ZIO_field(): Unit = {
+    assertEquals(
+      "val vNonZIO = zio.ZIO.service[Example.Service].map(_.vNonZIO)",
+      field("vNonZIO").getText
+    )
+    assertEquals(
+      Right("ZIO[Has[Example.Service], Nothing, Boolean]"),
+      field("vNonZIO").`type`().map(_.codeText)
+    )
+  }
 
-  def test_generates_accessor_function_for_non_ZIO_method_with_argument(): Unit = assertEquals(
-    "def m1NonZIO(s: String) = zio.ZIO.service[Example.Service].map(_.m1NonZIO(s))",
-    method("m1NonZIO").getText
-  )
+  def test_generates_accessor_function_for_non_ZIO_method_without_arguments(): Unit = {
+    assertEquals(
+      "def m0NonZIO = zio.ZIO.service[Example.Service].map(_.m0NonZIO)",
+      method("m0NonZIO").getText
+    )
+    assertEquals(
+      Right("ZIO[Has[Example.Service], Nothing, Unit]"),
+      method("m0NonZIO").`type`().map(_.codeText)
+    )
+  }
+
+  def test_generates_accessor_function_for_non_ZIO_method_with_argument(): Unit = {
+    assertEquals(
+      "def m1NonZIO(s: String) = zio.ZIO.service[Example.Service].map(_.m1NonZIO(s))",
+      method("m1NonZIO").getText
+    )
+    assertEquals(
+      Right("String => ZIO[Has[Example.Service], Nothing, Int]"),
+      method("m1NonZIO").`type`().map(_.codeText)
+    )
+  }
 
   def test_generates_accessor_function_for_generic_non_ZIO_method_with_multiple_arg_lists_default_args_and_varargs()
-    : Unit = assertEquals(
-    """def m2NonZIO[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.service[Example.Service].map(_.m2NonZIO[T](s2)(p)(i2: _*))""",
-    method("m2NonZIO").getText
-  )
+    : Unit = {
+    assertEquals(
+      """def m2NonZIO[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.service[Example.Service].map(_.m2NonZIO[T](s2)(p)(i2: _*))""",
+      method("m2NonZIO").getText
+    )
+    assertEquals(
+      Right("ZIO[Has[Example.Service], Nothing, Double]"),
+      method("m2NonZIO").returnType.map(_.codeText)
+    )
+  }
+
+  def test_generates_accessor_function_for_ZIO_method_returning_stream(): Unit = {
+    assertEquals(
+      """def stream(n: Int) = zio.ZIO.service[Example.Service].map(_.stream(n))""",
+      method("stream").getText
+    )
+    assertEquals(
+      Right("Int => ZIO[Has[Example.Service], Nothing, ZStream[Any, String, Int]]"),
+      method("stream").`type`().map(_.codeText)
+    )
+  }
 
 }

--- a/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
@@ -5,75 +5,75 @@ import com.intellij.psi.util.PsiTreeUtil
 import intellij.testfixtures._
 import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
 import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
-import org.jetbrains.plugins.scala.lang.macros.SynteticInjectorsTestUtils._
-import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
-import org.jetbrains.plugins.scala.lang.psi.api.base.{ScAnnotation, ScLiteral}
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
 import org.jetbrains.plugins.scala.lang.psi.types.PhysicalMethodSignature
 import org.junit.Assert._
 
 class ModulePatternAccessibleTest extends ScalaLightCodeInsightFixtureTestAdapter {
-  private val caret          = "<caret>"
-  private val annotationQual = "zio.macros.annotation.accessible"
+  private val caret = "<caret>"
 
   override def librariesLoaders: Seq[LibraryLoader] =
-    super.librariesLoaders :+ IvyManagedLoader("dev.zio" %% "zio-macros-core" % "0.5.0")
+    super.librariesLoaders :+ IvyManagedLoader("dev.zio" %% "zio-macros" % "1.0.0-RC20")
 
-  def fromAnnotation(clazz: ScTypeDefinition): Option[String] =
-    clazz.annotations(annotationQual).headOption.flatMap {
-      case annotation: ScAnnotation =>
-        annotation.annotationExpr.getAnnotationParameters.headOption.map {
-          case lit: ScLiteral => lit.getValue().toString
-        }
-      case _ => None
-    }
-
-  def accessor(text: String): ScFunctionDefinition = {
+  def extendedObject(text: String): ScObject = {
     val cleaned  = StringUtil.convertLineSeparators(text)
     val caretPos = cleaned.indexOf(caret)
     getFixture.configureByText("dummy.scala", cleaned.replace(caret, ""))
 
-    val clazz = PsiTreeUtil.findElementOfClassAtOffset(
+    PsiTreeUtil.findElementOfClassAtOffset(
       getFile,
       caretPos,
-      classOf[ScTypeDefinition],
+      classOf[ScObject],
       false
     )
+  }
 
-    val accessorName = fromAnnotation(clazz)
-      .getOrElse(fail(s"Unable to extract the companion name from the '${annotationQual}' annotation argument"))
-
-    val accessorDef = ScalaPsiUtil
-      .getCompanionModule(clazz)
-      .getOrElse(clazz.asInstanceOf[ScObject])
-      .allMethods
+  def method(obj: ScObject, name: String): ScFunctionDefinition =
+    obj.allMethods
       .collectFirst {
-        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == accessorName => fun
+        case PhysicalMethodSignature(fun: ScFunctionDefinition, _) if fun.name == name => fun
       }
-
-    accessorDef
       .getOrElse(
-        fail(s"Accessor definition '$accessorName' was not found inside the companion object of ${clazz.name}")
+        fail(s"Method declaration $name was not found inside object ${obj.name}")
           .asInstanceOf[ScFunctionDefinition]
       )
-  }
 
   def test_generates_accessor_function_in_companion(): Unit = {
     val code =
       s"""
-import zio.macros.annotation.accessible
+import zio._
+import zio.blocking.Blocking
+import zio.macros.accessible
 
-@accessible(">")
-trait E${caret}xample {
-  val example: Example.Service[Any]
-}
+@accessible
+object E${caret}xample {
+  type Environment = Blocking
 
-object Example {
-  trait Service[R] {}
+  type EIO[+T] = ZIO[Environment, Nothing, T]
+
+  trait Service {
+    val v: EIO[Boolean]
+    def m0: EIO[Unit]
+    def m1(s: String): EIO[Int]
+    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
+  }
 }
 """
 
-    accessor(code) mustBeExactly `def`(">", "Example.Service[Example]")
+    val scObject = extendedObject(code)
+
+    assertEquals(
+      "def m0 = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m0)",
+      method(scObject, "m0").getText
+    )
+    assertEquals(
+      "def m1(s: String) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m1(s))",
+      method(scObject, "m1").getText
+    )
+    assertEquals(
+      """def m3[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m3[T](s2)(p)(i2: _*))""",
+      method(scObject, "m3").getText
+    )
   }
 }


### PR DESCRIPTION
Currently accessor object extends `Service`, which is not correct: there is no `Service` in `Environment`.

This PR adds accessor object generation.
For this annotation usage:
```scala
@accessible
object Example {
  type Environment = Blocking

  type EIO[+T] = ZIO[Environment, Nothing, T]

  trait Service {
    val v: EIO[Boolean]
    def m0: EIO[Unit]
    def m1(s: String): EIO[Int]
    def m3[T](s2: String = "")(p: (T, Int))(i2: Int*): EIO[Double]
  }
}
```
We'll get such result:
```scala
object Example {
  ...

  val v = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.v)
  def m0 = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m0)
  def m1(s: String) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m1(s))
  def m3[T](s2: String = "")(p: (T, Int))(i2: Int*) = zio.ZIO.access[zio.Has[Example.Service]](_.get).flatMap(_.m3[T](s2)(p)(i2: _*))
}
```
Idea is able to get correct result types for type inference.

Thanks to @timaliberdov  this PR generates correct result types for methods with not-ZIO result types.

This PR also updates `@accessible` to `1.0.0-RC18-2` `Has` notation.
