### PR TITLE
Detect possibly erroneous wrapping of Try, Future, Option, and Either in ZIO

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -84,10 +84,17 @@
                          shortName="UnusedZIOExpressionsInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.WrapInsteadOfLiftInspection"
+                         displayName="Detects Future, Try, Option, and Either mistakenly wrapped in ZIO instead of using the ZIO.from* functions"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="WrapInsteadOfLiftInspection" level="WEAK WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
+
         <localInspection implementationClass="zio.intellij.inspections.mistakes.YieldingZIOEffectInspection"
                          displayName="Detects if a ZIO is returned inside the yield part of a for comprehension"
                          groupPath="Scala,ZIO" groupName="Inspections"
-                         shortName="YieldingZIOEffectInspection" level="WARNING"
+                         shortName="YieldingZIOEffectInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
 
         <intentionAction>

--- a/src/main/resources/inspectionDescriptions/WrapInsteadOfLiftInspection.html
+++ b/src/main/resources/inspectionDescriptions/WrapInsteadOfLiftInspection.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+Detects Future, Try, Option, and Either mistakenly wrapped in ZIO instead of using the <code>ZIO.from*</code> functions.
+
+Instead of:
+<pre>
+val myFuture = Future { someComputation() }
+ZIO.effect(myFuture)
+</pre>
+<br/>
+Will highlight and suggest fixing it by using the appropriate ZIO function:
+<pre>
+ZIO.fromFuture(implicit ec => myFuture)
+</pre>
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/mistakes/WrapInsteadOfLiftInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/WrapInsteadOfLiftInspection.scala
@@ -1,0 +1,62 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection.{InspectionManager, LocalQuickFix, ProblemDescriptor, ProblemHighlightType}
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractRegisteredInspection}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createExpressionFromText
+import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker
+import zio.intellij.inspections._
+import zio.intellij.inspections.mistakes.WrapInsteadOfLiftInspection.messageFormat
+
+class WrapInsteadOfLiftInspection extends AbstractRegisteredInspection {
+
+  override protected def problemDescriptor(
+    element: PsiElement,
+    maybeQuickFix: Option[LocalQuickFix],
+    descriptionTemplate: String,
+    highlightType: ProblemHighlightType
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] = {
+
+    def createFix(expr: ScExpression, wrappedEffect: String, localFix: LocalQuickFix): ProblemDescriptor =
+      manager.createProblemDescriptor(
+        expr,
+        messageFormat.format(wrappedEffect, wrappedEffect),
+        isOnTheFly,
+        Array(localFix),
+        ProblemHighlightType.WEAK_WARNING
+      )
+
+    element match {
+      case expr: ScExpression if IntentionAvailabilityChecker.checkInspection(this, expr.getParent) =>
+        expr match {
+          case Future(f) => Some(createFix(expr, "Future", new FutureToZio(expr, f)))
+          case _         => None
+        }
+      case _ => None
+    }
+  }
+
+  object Future {
+
+    def unapply(expr: ScExpression): Option[ScExpression] = expr match {
+      case `ZIO`(scalaFuture(f))             => Some(f)
+      case `ZIO.apply`(scalaFuture(f))       => Some(f)
+      case `ZIO.effect`(scalaFuture(f))      => Some(f)
+      case `ZIO.effectTotal`(scalaFuture(f)) => Some(f)
+      case _                                 => None
+    }
+  }
+}
+
+final class FutureToZio(toReplace: ScExpression, replaceWith: ScExpression)
+    extends AbstractFixOnPsiElement("Replace with ZIO.fromFuture", toReplace) {
+
+  override protected def doApplyFix(element: ScExpression)(implicit project: Project): Unit =
+    element.replace(createExpressionFromText(s"ZIO.fromFuture(implicit ec => ${replaceWith.getText}"))
+}
+
+object WrapInsteadOfLiftInspection {
+  val messageFormat = "Possibly mistaken wrapping of %s in a ZIO effect. Perhaps you meant to use ZIO.from%s?"
+}

--- a/src/main/scala/zio/intellij/inspections/mistakes/YieldingZIOEffectInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/YieldingZIOEffectInspection.scala
@@ -29,13 +29,11 @@ class YieldingZIOEffectInspection extends AbstractRegisteredInspection {
     element match {
       case expr: ScFor if IntentionAvailabilityChecker.checkInspection(this, expr.getParent) =>
         expr.body match {
-          case Some(body @ zioRef(_, _)) =>
-            Some(createDescriptor(body))
+          case Some(body @ zioRef(_, _)) => Some(createDescriptor(body))
           case Some(e: ScBlock) =>
             e.exprs.lastOption match {
-              case Some(body @ zioRef(_, _)) =>
-                Some(createDescriptor(body))
-              case None => None
+              case Some(body @ zioRef(_, _)) => Some(createDescriptor(body))
+              case None                      => None
             }
           case _ => None
         }
@@ -44,5 +42,5 @@ class YieldingZIOEffectInspection extends AbstractRegisteredInspection {
 }
 
 object YieldingZIOEffectInspection {
-  val message = "Returning a ZIO inside the yield part of a for comprehension"
+  val message = "Possibly mistaken yielding of a ZIO effect. Perhaps you meant to yield the result instead?"
 }

--- a/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
+++ b/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
@@ -8,6 +8,165 @@ abstract class BaseWrapInsteadOfLiftInspectionTest(s: String)
   override protected val description = WrapInsteadOfLiftInspection.messageFormat.format(s, s)
 }
 
+class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Option") {
+
+  val hint = "Replace with ZIO.fromOption"
+
+  def test_option_reference_ctor(): Unit = {
+    z(s"""val o: Option[Int] = Option(42)
+         |${START}ZIO(o)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val o: Option[Int] = Option(42)
+                    |ZIO(o)""".stripMargin)
+    val result = z(s"""val o: Option[Int] = Option(42)
+                      |ZIO.fromOption(o)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_option_reference_apply(): Unit = {
+    z(s"""val o: Option[Int] = Option(42)
+         |${START}ZIO.apply(o)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val o: Option[Int] = Option(42)
+                    |ZIO.apply(o)""".stripMargin)
+    val result = z(s"""val o: Option[Int] = Option(42)
+                      |ZIO.fromOption(o)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_option_direct_some(): Unit = {
+    z(s"${START}ZIO(Some(42))$END").assertHighlighted()
+    val text   = z(s"ZIO(Some(42))")
+    val result = z(s"ZIO.fromOption(Some(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_direct_none(): Unit = {
+    z(s"${START}ZIO(None)$END").assertHighlighted()
+    val text   = z(s"ZIO(None)")
+    val result = z(s"ZIO.fromOption(None)")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_option_effect(): Unit = {
+    z(s"${START}ZIO.effect(Option(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effect(Option(42))")
+    val result = z(s"ZIO.fromOption(Option(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_option_effectTotal(): Unit = {
+    z(s"${START}ZIO.effectTotal(Option(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effectTotal(Option(42))")
+    val result = z(s"ZIO.fromOption(Option(42))")
+    testQuickFix(text, result, hint)
+  }
+}
+
+class TryWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Try") {
+
+  val hint = "Replace with ZIO.fromTry"
+
+  def test_try_reference_ctor(): Unit = {
+    z(s"""val t: Try[Int] = Try(42)
+         |${START}ZIO(t)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val t: Try[Int] = Try(42)
+                    |ZIO(t)""".stripMargin)
+    val result = z(s"""val t: Try[Int] = Try(42)
+                      |ZIO.fromTry(t)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_try_reference_apply(): Unit = {
+    z(s"""val t: Try[Int] = Try(42)
+         |${START}ZIO.apply(t)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val t: Try[Int] = Try(42)
+                    |ZIO.apply(t)""".stripMargin)
+    val result = z(s"""val t: Try[Int] = Try(42)
+                      |ZIO.fromTry(t)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_try_direct_success(): Unit = {
+    z(s"${START}ZIO(Success(42))$END").assertHighlighted()
+    val text   = z(s"ZIO(Success(42))")
+    val result = z(s"ZIO.fromTry(Success(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_direct_failure(): Unit = {
+    z(s"${START}ZIO(Failure(new Exception()))$END").assertHighlighted()
+    val text   = z(s"ZIO(Failure(new Exception()))")
+    val result = z(s"ZIO.fromTry(Failure(new Exception()))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_try_effect(): Unit = {
+    z(s"${START}ZIO.effect(Try(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effect(Try(42))")
+    val result = z(s"ZIO.fromTry(Try(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_try_effectTotal(): Unit = {
+    z(s"${START}ZIO.effectTotal(Try(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effectTotal(Try(42))")
+    val result = z(s"ZIO.fromTry(Try(42))")
+    testQuickFix(text, result, hint)
+  }
+}
+
+class EitherWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Either") {
+
+  val hint = "Replace with ZIO.fromEither"
+
+  def test_either_reference_ctor(): Unit = {
+    z(s"""val either: Either[String, Int] = Right(42)
+         |${START}ZIO(either)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val either: Either[String, Int] = Right(42)
+                    |ZIO(either)""".stripMargin)
+    val result = z(s"""val either: Either[String, Int] = Right(42)
+                      |ZIO.fromEither(either)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_reference_apply(): Unit = {
+    z(s"""val either: Either[String, Int] = Right(42)
+         |${START}ZIO.apply(either)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val either: Either[String, Int] = Right(42)
+                    |ZIO.apply(either)""".stripMargin)
+    val result = z(s"""val either: Either[String, Int] = Right(42)
+                      |ZIO.fromEither(either)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_direct_right(): Unit = {
+    z(s"${START}ZIO(Right(42))$END").assertHighlighted()
+    val text   = z(s"ZIO(Right(42))")
+    val result = z(s"ZIO.fromEither(Right(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_direct_left(): Unit = {
+    z(s"${START}ZIO(Left(42))$END").assertHighlighted()
+    val text   = z(s"ZIO(Left(42))")
+    val result = z(s"ZIO.fromEither(Left(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_effect(): Unit = {
+    z(s"${START}ZIO.effect(Right(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effect(Right(42))")
+    val result = z(s"ZIO.fromEither(Right(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_either_effectTotal(): Unit = {
+    z(s"${START}ZIO.effectTotal(Right(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effectTotal(Right(42))")
+    val result = z(s"ZIO.fromEither(Right(42))")
+    testQuickFix(text, result, hint)
+  }
+}
+
 class FutureWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Future") {
 
   val hint = "Replace with ZIO.fromFuture"
@@ -26,7 +185,7 @@ class FutureWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Futu
     z(s"""val future = Future(42)
          |${START}ZIO.apply(future)$END""".stripMargin).assertHighlighted()
     val text   = z(s"""val future = Future(42)
-                      |ZIO.apply(future)""".stripMargin)
+                    |ZIO.apply(future)""".stripMargin)
     val result = z(s"""val future = Future(42)
                       |ZIO.fromFuture(implicit ec => future)""".stripMargin)
     testQuickFix(text, result, hint)

--- a/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
+++ b/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
@@ -1,0 +1,62 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.mistakes.WrapInsteadOfLiftInspection
+
+abstract class BaseWrapInsteadOfLiftInspectionTest(s: String)
+    extends ZScalaInspectionTest[WrapInsteadOfLiftInspection] {
+  override protected val description = WrapInsteadOfLiftInspection.messageFormat.format(s, s)
+}
+
+class FutureWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Future") {
+
+  val hint = "Replace with ZIO.fromFuture"
+
+  def test_future_reference_ctor(): Unit = {
+    z(s"""val future = Future(42)
+         |${START}ZIO(future)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val future = Future(42)
+                    |ZIO(future)""".stripMargin)
+    val result = z(s"""val future = Future(42)
+                      |ZIO.fromFuture(implicit ec => future)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_future_reference_apply(): Unit = {
+    z(s"""val future = Future(42)
+         |${START}ZIO.apply(future)$END""".stripMargin).assertHighlighted()
+    val text   = z(s"""val future = Future(42)
+                      |ZIO.apply(future)""".stripMargin)
+    val result = z(s"""val future = Future(42)
+                      |ZIO.fromFuture(implicit ec => future)""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+
+  def test_future_direct_method(): Unit = {
+    z(s"${START}ZIO(Future(42))$END").assertHighlighted()
+    val text   = z(s"ZIO(Future(42))")
+    val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_future_effect(): Unit = {
+    z(s"${START}ZIO.effect(Future(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effect(Future(42))")
+    val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_future_effectTotal(): Unit = {
+    z(s"${START}ZIO.effectTotal(Future(42))$END").assertHighlighted()
+    val text   = z(s"ZIO.effectTotal(Future(42))")
+    val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_zio_alias_task(): Unit = {
+    z(s"${START}Task.effectTotal(Future(42))$END").assertHighlighted()
+    val text   = z(s"Task.effectTotal(Future(42))")
+    val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
+    testQuickFix(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
@@ -24,6 +24,8 @@ trait ZInspectionTestBase[T <: LocalInspectionTool] { base: ScalaInspectionTestB
        |import zio.duration._
        |import zio.test._
        |import zio.test.Assertion._
+       |import scala.concurrent.Future
+       |import scala.concurrent.ExecutionContext.Implicits.global
        |object Test {
        |
        |  val logger: Logger = null

--- a/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
@@ -26,6 +26,7 @@ trait ZInspectionTestBase[T <: LocalInspectionTool] { base: ScalaInspectionTestB
        |import zio.test.Assertion._
        |import scala.concurrent.Future
        |import scala.concurrent.ExecutionContext.Implicits.global
+       |import scala.util._
        |object Test {
        |
        |  val logger: Logger = null


### PR DESCRIPTION
Fixes #62 

Adds a hint and a quickfix for converting values of types Try (also `Success` and `Failure`), etc, to the corresponding ZIO `from*` combinatior:

![image](https://user-images.githubusercontent.com/601206/80613264-b4dd4d00-8a45-11ea-9eba-2e16f97ec08f.png)

![image](https://user-images.githubusercontent.com/601206/80613273-b9096a80-8a45-11ea-8aef-c3ba0aa6a07a.png)

