### PR TITLE
Detecting the use of Nothing in contravariant positions of R type parameter in ZIO types

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -97,6 +97,12 @@
                          shortName="YieldingZIOEffectInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.NothingInContravariantPositionInspection"
+                         displayName="Detects Nothing being used in the contravariant position in a ZIO effect"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="NothingInContravariantPositionInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>

--- a/src/main/resources/inspectionDescriptions/NothingInContravariantPositionInspection.html
+++ b/src/main/resources/inspectionDescriptions/NothingInContravariantPositionInspection.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+Detects if <code>Nothing</code> was placed in the <code>R</code> type parameter. Having <code>Nothing</code> in the
+contravariant position is most likely a mistake, where the use of <code>Any</code> was intended.
+<pre>
+val x: ZIO[Nothing, Nothing, Unit] = ???
+</pre>
+<br/>
+Will highlight the <code>Nothing</code> parameter, as it is impossible to satisfy the <code>R</code> requirement with it.<br/>
+
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/mistakes/NothingInContravariantPositionInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/NothingInContravariantPositionInspection.scala
@@ -1,0 +1,55 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection._
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.AbstractRegisteredInspection
+import org.jetbrains.plugins.scala.codeInspection.collections.isOfClassFrom
+import org.jetbrains.plugins.scala.extensions._
+import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScParameterizedTypeElement
+import org.jetbrains.plugins.scala.lang.psi.api.statements._
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
+import zio.intellij.inspections.zioLikePackages
+
+class NothingInContravariantPositionInspection extends AbstractRegisteredInspection {
+
+  override protected def problemDescriptor(
+    element: PsiElement,
+    maybeQuickFix: Option[LocalQuickFix],
+    descriptionTemplate: String,
+    highlightType: ProblemHighlightType
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
+    (element.parent, element) match {
+      case (
+          Some(_: ScTypeAliasDefinition | _: ScFunctionDefinition | _: ScPatternDefinition),
+          p @ ScParameterizedTypeElement(_, params)
+          ) =>
+        p.`type`().toOption match {
+          case Some(tpe) if isOfClassFrom(tpe, zioLikePackages) =>
+            tpe.extractDesignated(false) match {
+              case Some(d: ScTypeParametersOwner) =>
+                d.typeParameters.zip(params).collectFirst {
+                  case (tp, elem)
+                      if tp.isContravariant && elem.`type`().exists(_.isNothing) &&
+                        // TODO hack, think of a better heuristic for this
+                        // only prevent contravariant R (and R*) positions
+                        tp.name.startsWith("R") =>
+                    manager.createProblemDescriptor(
+                      elem,
+                      NothingInContravariantPositionInspection.message,
+                      isOnTheFly,
+                      Array.empty[LocalQuickFix],
+                      ProblemHighlightType.WARNING
+                    )
+                }
+              case _ => None
+            }
+          case _ => None
+
+        }
+      case _ => None
+    }
+
+}
+object NothingInContravariantPositionInspection {
+  val message = "Possibly erroneous use of Nothing in the R type parameter. Perhaps you meant to use Any?"
+}

--- a/src/test/scala/zio/inspections/NothingInContravariantPositionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/NothingInContravariantPositionInspectionTest.scala
@@ -1,0 +1,28 @@
+package zio.inspections
+
+import zio.intellij.inspections.mistakes.NothingInContravariantPositionInspection
+
+class NothingInContravariantPositionInspectionTest
+    extends ZScalaInspectionTest[NothingInContravariantPositionInspection] {
+  import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  override protected val description = NothingInContravariantPositionInspection.message
+
+  def test_function_def(): Unit =
+    z(s"def foo: ZIO[${START}Nothing$END, Nothing, Unit] = ???").assertHighlighted()
+
+  def test_value_def(): Unit =
+    z(s"val foo: ZIO[${START}Nothing$END, Nothing, Unit] = ???").assertHighlighted()
+
+  def test_type_alias(): Unit =
+    z(s"type Test[+A] = ZIO[${START}Nothing$END, Nothing, A] = ???").assertHighlighted()
+
+  def test_does_not_highlight_usage(): Unit =
+    z(s"def foo(z: ZIO[${START}Nothing$END, Nothing, Unit]) = ???").assertNotHighlighted()
+
+  def test_highlights_Nothing_in_R(): Unit =
+    z(s"type Dequeue[+A] = ZQueue[${START}Nothing$END, Nothing, Any, Nothing, Nothing, A]").assertHighlighted()
+
+  def test_does_not_highlight_non_R_contravariant_positions(): Unit =
+    z(s"type Dequeue[+A] = ZQueue[Any, Nothing, Any, Nothing, ${START}Nothing$END, A]").assertNotHighlighted()
+}

--- a/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
@@ -45,6 +45,19 @@ trait ZInspectionTestBase[T <: LocalInspectionTool] { base: ScalaInspectionTestB
 
   implicit protected class S(s: String) {
     def assertHighlighted(): Unit = checkTextHasError(s)
+
+    def assertNotHighlighted(): Unit = {
+      var thrownEx: AssertionError = null // ;(
+      try checkTextHasError(s)
+      catch {
+        case e: AssertionError => thrownEx = e
+      }
+      finally {
+        if (thrownEx != null) ()
+        else throw new AssertionError("An error from the highlighter was expected to be thrown, but wasn't.")
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
Fixes #64 