### PR TITLE
Incorrect unit suggestion

### DIFF
--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -6,6 +6,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTemplateDefinition}
 
 package object inspections {
@@ -39,7 +40,7 @@ package object inspections {
   def fromZio(r: ScExpression): Boolean =
     isOfClassFrom(r, zioLikePackages)
 
-  class ZIOMemberReference(refName: String) {
+  class ZIOStaticMemberReference(refName: String) {
     private def matchesRefName(ref: ScReferenceExpression) =
       if (ref.refName == refName) true
       else
@@ -52,19 +53,19 @@ package object inspections {
     def unapply(expr: ScExpression): Option[ScExpression] = expr match {
       case ref @ ScReferenceExpression(_) if matchesRefName(ref) =>
         ref.smartQualifier match {
-          case Some(ZIOMemberReference()) => Some(expr)
-          case _                          => None
+          case Some(ZIOStaticMemberReference()) => Some(expr)
+          case _                                => None
         }
       case MethodRepr(_, _, Some(ref), Seq(e)) if matchesRefName(ref) =>
         ref match {
-          case ZIOMemberReference() => Some(e)
-          case _                    => None
+          case ZIOStaticMemberReference() => Some(e)
+          case _                          => None
         }
       case _ => None
     }
   }
 
-  object ZIOMemberReference {
+  object ZIOStaticMemberReference {
     // todo make me not do this
     val zioTypes = Set("zio.ZIO", "zio.UIO", "zio.RIO", "zio.URIO", "zio.IO", "zio.Task")
 
@@ -96,15 +97,15 @@ package object inspections {
   val scalaOption = new TypeReference(Set("scala.Option", "scala.Some", "scala.None"))
   val scalaEither = new TypeReference(Set("scala.util.Either", "scala.util.Left", "scala.util.Right"))
 
-  val `ZIO.apply`         = new ZIOMemberReference("apply")
-  val `ZIO.unit`          = new ZIOMemberReference("unit")
-  val `ZIO.succeed`       = new ZIOMemberReference("succeed")
-  val `ZIO.fail`          = new ZIOMemberReference("fail")
-  val `ZIO.collectAll`    = new ZIOMemberReference("collectAll")
-  val `ZIO.collectAllPar` = new ZIOMemberReference("collectAllPar")
-  val `ZIO.sleep`         = new ZIOMemberReference("sleep")
-  val `ZIO.effect`        = new ZIOMemberReference("effect")
-  val `ZIO.effectTotal`   = new ZIOMemberReference("effectTotal")
+  val `ZIO.apply`         = new ZIOStaticMemberReference("apply")
+  val `ZIO.unit`          = new ZIOStaticMemberReference("unit")
+  val `ZIO.succeed`       = new ZIOStaticMemberReference("succeed")
+  val `ZIO.fail`          = new ZIOStaticMemberReference("fail")
+  val `ZIO.collectAll`    = new ZIOStaticMemberReference("collectAll")
+  val `ZIO.collectAllPar` = new ZIOStaticMemberReference("collectAllPar")
+  val `ZIO.sleep`         = new ZIOStaticMemberReference("sleep")
+  val `ZIO.effect`        = new ZIOStaticMemberReference("effect")
+  val `ZIO.effectTotal`   = new ZIOStaticMemberReference("effectTotal")
 
   object unit {
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
@@ -12,7 +12,7 @@ class SimplifyCollectAllInspection
       CollectAllParNToForeachParNSimplificationType
     )
 
-sealed abstract class BaseCollectAllSimplificationType(methodName: String, methodExtractor: ZIOMemberReference)
+sealed abstract class BaseCollectAllSimplificationType(methodName: String, methodExtractor: ZIOStaticMemberReference)
     extends SimplificationType {
   override def hint: String = s"Replace with ZIO.$methodName"
 

--- a/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
@@ -35,4 +35,8 @@ class SimplifyUnitInspectionTest extends ZSimplifyInspectionTest[SimplifyUnitIns
     val result = z("ZIO.succeed(42).unit")
     testQuickFix(text, result, hint)
   }
+
+  def test_does_not_highlight_unit_member(): Unit = {
+    z(s"""UIO(println("a")) $START*> UIO(println("b")).unit$END""").assertNotHighlighted()
+  }
 }

--- a/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
+++ b/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
@@ -39,7 +39,7 @@ class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Opti
     testQuickFix(text, result, hint)
   }
 
-  def test_either_direct_none(): Unit = {
+  def test_option_direct_none(): Unit = {
     z(s"${START}ZIO(None)$END").assertHighlighted()
     val text   = z(s"ZIO(None)")
     val result = z(s"ZIO.fromOption(None)")
@@ -92,7 +92,7 @@ class TryWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Try") {
     testQuickFix(text, result, hint)
   }
 
-  def test_either_direct_failure(): Unit = {
+  def test_try_direct_failure(): Unit = {
     z(s"${START}ZIO(Failure(new Exception()))$END").assertHighlighted()
     val text   = z(s"ZIO(Failure(new Exception()))")
     val result = z(s"ZIO.fromTry(Failure(new Exception()))")


### PR DESCRIPTION
Fixes #78 

Wow, this was trickier than I thought...

The main problem stems from there being both `ZIO.unit` as well as an instance `unit` member. My check was for a function "from a type belonging to `zio._`". I now changed it to explicitly check for static members of zio.ZIO (and aliases)