### PR TITLE
Add Dump ZIO Fibers debug action

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -159,6 +159,17 @@
     </extensions>
 
     <actions>
-        <!-- Add your actions here -->
+        <action id="DumpFibers"
+                class="zio.intellij.actions.FiberDumpAction"
+                text="Get ZIO Fiber Dump"
+                icon="AllIcons.Actions.Dump">
+            <add-to-group group-id="DebuggingActionsGroup" anchor="before" relative-to-action="DumpThreads"/>
+        </action>
+
+        <group id="XDebugger.ToolWindow.DumpFibers">
+            <separator/>
+            <reference ref="DumpFibers"/>
+            <add-to-group group-id="XDebugger.ToolWindow.LeftToolbar" anchor="last"/>
+        </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/icons/sortById.svg
+++ b/src/main/resources/icons/sortById.svg
@@ -1,0 +1,22 @@
+<!-- This icon was taken from the intellij-community project and modified -->
+<!-- https://github.com/JetBrains/intellij-community/blob/48036571856fa3482e394e9bec2a33f9876871b0/platform/icons/src/objectBrowser/sortedByUsage.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g fill="none" fill-rule="evenodd">
+        <rect width="2" height="9" x="4" y="2" fill="#6E6E6E"/>
+        <polygon fill="#6E6E6E" points="5 10 9 14 1 14" transform="matrix(1 0 0 -1 0 24)"/>
+    </g>
+    <text x="8.1459999"
+          y="10.655"
+          fill="#6E6E6E"
+          font-size="8px"
+          font-family="JetBrains Mono">
+        <tspan y="10.655" x="8.1459999">i</tspan>
+    </text>
+    <text x="11.90504"
+          y="10.652343"
+          fill="#6E6E6E"
+          font-size="8px"
+          font-family="JetBrains Mono">
+        <tspan y="10.652343" x="11.90504">d</tspan>
+    </text>
+</svg>

--- a/src/main/resources/icons/sortById_dark.svg
+++ b/src/main/resources/icons/sortById_dark.svg
@@ -1,0 +1,22 @@
+<!-- This icon was taken from the intellij-community project and modified -->
+<!-- https://github.com/JetBrains/intellij-community/blob/48036571856fa3482e394e9bec2a33f9876871b0/platform/icons/src/objectBrowser/sortedByUsage_dark.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+    <g fill="none" fill-rule="evenodd">
+        <rect width="2" height="9" x="4" y="2" fill="#AFB1B3"/>
+        <polygon fill="#AFB1B3" points="5 10 9 14 1 14" transform="matrix(1 0 0 -1 0 24)"/>
+    </g>
+    <text x="8.1459999"
+          y="10.655"
+          fill="#AFB1B3"
+          font-size="8px"
+          font-family="JetBrains Mono">
+        <tspan y="10.655" x="8.1459999">i</tspan>
+    </text>
+    <text x="11.90504"
+          y="10.652343"
+          fill="#AFB1B3"
+          font-size="8px"
+          font-family="JetBrains Mono">
+        <tspan y="10.652343" x="11.90504">d</tspan>
+    </text>
+</svg>

--- a/src/main/scala/zio/intellij/actions/FiberDumpAction.scala
+++ b/src/main/scala/zio/intellij/actions/FiberDumpAction.scala
@@ -1,0 +1,216 @@
+package zio.intellij.actions
+
+import com.intellij.debugger.DebuggerManagerEx
+import com.intellij.debugger.engine.JavaValue
+import com.intellij.execution.filters.{ExceptionFilters, TextConsoleBuilderFactory}
+import com.intellij.execution.ui.RunnerLayoutUi
+import com.intellij.execution.ui.layout.impl.RunnerContentUi
+import com.intellij.notification.NotificationGroup
+import com.intellij.openapi.actionSystem.{AnAction, AnActionEvent, DefaultActionGroup}
+import com.intellij.openapi.application.{ApplicationManager, ModalityState}
+import com.intellij.openapi.project.{DumbAwareAction, Project}
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.ui.MessageType
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.text.DateFormatUtil
+import com.intellij.xdebugger.evaluation.EvaluationMode
+import com.intellij.xdebugger.frame.XValue
+import com.intellij.xdebugger.impl.breakpoints.XExpressionImpl
+import com.intellij.xdebugger.impl.ui.tree.nodes.XEvaluationCallbackBase
+import com.sun.jdi._
+import org.jetbrains.plugins.scala.ScalaLanguage
+import org.jetbrains.plugins.scala.project.{LibraryExt, ModuleExt, ProjectExt, ScalaLanguageLevel}
+import zio.intellij.ui.FiberDumpPanel
+import zio.intellij.utils
+import zio.intellij.utils.Version
+import zio.intellij.utils.jdi._
+import zio.intellij.utils.jdi.fiber._
+import zio.intellij.utils.jdi.fiber.model.FiberInfo
+
+import scala.annotation.tailrec
+
+final class FiberDumpAction extends DumbAwareAction with AnAction.TransparentUpdate {
+
+  override def actionPerformed(event: AnActionEvent): Unit = {
+
+    val project = event.getProject
+    if (project != null) {
+      val sourceModules = project.modulesWithScala.filter(_.isSourceModule)
+
+      // should work for non-sbt projects
+      val zioVersion = (for {
+        module  <- sourceModules
+        library <- module.libraries
+        url     <- library.getUrls(OrderRootType.CLASSES)
+        if url.contains("/dev/zio/zio_")
+        trimmedUrl = utils.trimAfterSuffix(url, ".jar")
+        versionStr <- LibraryExt.runtimeVersion(trimmedUrl)
+        version    <- Version.parse(versionStr)
+      } yield version).headOption
+
+      implicit val scalaLanguageLevel: ScalaLanguageLevel =
+        sourceModules
+          .flatMap(_.scalaLanguageLevel)
+          .headOption
+          .getOrElse(ScalaLanguageLevel.getDefault)
+
+      zioVersion.fold(notifyAboutAbsentZioDependency(project)) { implicit version =>
+        if (version >= Version.ZIO.RC21) {
+          notifyAboutNotImplementedFunctionalityForRecentZIOVersions(project)
+        } else if (version < Version.ZIO.RC18) {
+          notifyAboutNotImplementedFunctionalityForOldZIOVersions(project)
+        } else {
+          invokeDumpAllFibers(project)
+        }
+      }
+    }
+  }
+
+  override def update(event: AnActionEvent): Unit = {
+    val presentation = event.getPresentation
+    val project      = event.getProject
+    if (project == null) {
+      presentation.setEnabled(false)
+    } else {
+      val debuggerSession = DebuggerManagerEx.getInstanceEx(project).getContext.getDebuggerSession
+      presentation.setEnabled(debuggerSession != null && debuggerSession.isAttached)
+    }
+  }
+
+  private def notifyAboutAbsentZioDependency(project: Project): Unit =
+    warningNotification(project, "ZIO dependency not found")
+
+  private def notifyAboutNotImplementedFunctionalityForRecentZIOVersions(project: Project): Unit =
+    warningNotification(
+      project,
+      "Dump Fibers functionality is not yet implemented for ZIO version 1.0.0-RC21 and above " +
+        "due to changes in fiber tracking"
+    )
+
+  private def notifyAboutNotImplementedFunctionalityForOldZIOVersions(project: Project): Unit =
+    warningNotification(
+      project,
+      "Dump Fibers functionality is not implemented for ZIO versions below 1.0.0-RC18 " +
+        "due to the fact that the Fiber.dumpAll was added in RC18"
+    )
+
+  private def warningNotification(project: Project, message: String): Unit =
+    FiberDumpAction.NOTIFICATION_GROUP
+      .createNotification(message, MessageType.WARNING)
+      .notify(project)
+
+  private def invokeDumpAllFibers(
+    project: Project
+  )(implicit zioVersion: Version, languageLevel: ScalaLanguageLevel): Unit = {
+    val debuggerContext = DebuggerManagerEx.getInstanceEx(project).getContext
+    val session         = debuggerContext.getDebuggerSession
+    if (session != null && session.isAttached) {
+      val process = debuggerContext.getDebugProcess
+
+      val evaluator = process.getXdebugProcess.getEvaluator
+      val fiberDumpAllExpr = new XExpressionImpl(
+        "new zio.BootstrapRuntime {}.unsafeRun(zio.Fiber.dumpAll).toArray",
+        ScalaLanguage.INSTANCE,
+        null,
+        EvaluationMode.EXPRESSION
+      )
+
+      process.getManagerThread.invoke { () =>
+        val vmProxy = process.getVirtualMachineProxy
+        evaluator.evaluate(
+          fiberDumpAllExpr,
+          new XEvaluationCallbackBase {
+            override def evaluated(result: XValue): Unit = {
+              vmProxy.suspend()
+              try {
+                val dump = buildFiberDump(result)
+                ApplicationManager.getApplication.invokeLater(
+                  () => {
+                    val xSession = session.getXDebugSession
+                    if (xSession != null) {
+                      FiberDumpAction.addFiberDump(project, dump, xSession.getUI, session.getSearchScope)
+                    }
+                  },
+                  ModalityState.NON_MODAL
+                )
+              } finally vmProxy.resume()
+            }
+
+            override def errorOccurred(errorMessage: String): Unit =
+              FiberDumpAction.NOTIFICATION_GROUP
+                .createNotification(
+                  s"Error during evaluation of Fiber.dumpAll: $errorMessage",
+                  MessageType.ERROR
+                )
+                .notify(project)
+          },
+          null
+        )
+      }
+    }
+  }
+
+  private def buildFiberDump(
+    xValue: XValue
+  )(implicit zioVersion: Version, languageLevel: ScalaLanguageLevel): List[FiberInfo] = {
+    @tailrec
+    def inner(fiberDumps: List[Value], acc: List[FiberInfo]): List[FiberInfo] =
+      if (fiberDumps.isEmpty) acc
+      else {
+        val rawResults           = fiberDumps.flatMap(convertFiberInfoWithChildren(_))
+        val currentLevelDump     = rawResults.map(_.info)
+        val currentLevelChildren = rawResults.flatMap(_.children)
+        inner(currentLevelChildren, acc ++ currentLevelDump)
+      }
+
+    xValue match {
+      case javaValue: JavaValue =>
+        val valueDescriptor = javaValue.getDescriptor
+        if (valueDescriptor == null) Nil
+        else {
+          val fullValueDescriptor = valueDescriptor.getFullValueDescriptor
+          if (fullValueDescriptor == null) Nil
+          else {
+            val dumpValues = convertScalaSeq(fullValueDescriptor.calcValue(javaValue.getEvaluationContext))
+            inner(dumpValues, Nil)
+          }
+        }
+      case _ => Nil
+    }
+  }
+
+}
+
+object FiberDumpAction {
+
+  val NOTIFICATION_GROUP: NotificationGroup = NotificationGroup.balloonGroup("Fiber Dump Notifications")
+
+  def addFiberDump(
+    project: Project,
+    fibers: List[FiberInfo],
+    ui: RunnerLayoutUi,
+    searchScope: GlobalSearchScope
+  ): Unit = {
+    val consoleView = TextConsoleBuilderFactory
+      .getInstance()
+      .createBuilder(project)
+      .filters(ExceptionFilters.getFilters(searchScope))
+      .getConsole
+    consoleView.allowHeavyFilters()
+    val toolbarActions = new DefaultActionGroup()
+    val panel          = new FiberDumpPanel(project, consoleView, toolbarActions, fibers)
+
+    val id      = s"Fiber Dump ${DateFormatUtil.formatTimeWithSeconds(System.currentTimeMillis)}"
+    val content = ui.createContent(id, panel, id, null, null)
+    content.putUserData(RunnerContentUi.LIGHTWEIGHT_CONTENT_MARKER, java.lang.Boolean.TRUE)
+    content.setCloseable(true)
+    content.setDescription("Fiber Dump")
+    ui.addContent(content)
+    ui.selectAndFocus(content, true, true)
+
+    Disposer.register(content, consoleView)
+    ui.selectAndFocus(content, true, false)
+  }
+
+}

--- a/src/main/scala/zio/intellij/icons/package.scala
+++ b/src/main/scala/zio/intellij/icons/package.scala
@@ -1,0 +1,10 @@
+package zio.intellij
+
+import com.intellij.ui.IconManager
+import javax.swing.Icon
+
+package object icons {
+  private def load(path: String): Icon = IconManager.getInstance.getIcon(path, getClass)
+
+  val SortByIdIcon: Icon = load("/icons/sortById.svg")
+}

--- a/src/main/scala/zio/intellij/ide/FiberDumpToFileExporter.scala
+++ b/src/main/scala/zio/intellij/ide/FiberDumpToFileExporter.scala
@@ -1,0 +1,29 @@
+package zio.intellij.ide
+
+import java.io.File
+
+import com.intellij.ide.ExporterToTextFile
+import com.intellij.openapi.project.Project
+import zio.intellij.ide.FiberDumpToFileExporter.DEFAULT_REPORT_FILE_NAME
+import zio.intellij.ui.FiberDumpRenderer
+import zio.intellij.utils.jdi.fiber.model.FiberInfo
+
+/**
+ * This class was copied from the intellij-community project and modified
+ *
+ * https://github.com/JetBrains/intellij-community/blob/48036571856fa3482e394e9bec2a33f9876871b0/java/java-impl/src/com/intellij/unscramble/ThreadDumpPanel.java#L401
+ */
+class FiberDumpToFileExporter(project: Project, fiberDump: List[FiberInfo]) extends ExporterToTextFile {
+
+  override def getReportText: String =
+    fiberDump.map(FiberDumpRenderer.renderFiberInfo).mkString("\n\n")
+
+  override def getDefaultFilePath: String =
+    Option(project.getBasePath).fold("")(_ + File.separator + DEFAULT_REPORT_FILE_NAME)
+
+  override def canExport: Boolean = fiberDump.nonEmpty
+}
+
+object FiberDumpToFileExporter {
+  val DEFAULT_REPORT_FILE_NAME = "fibers_report.txt"
+}

--- a/src/main/scala/zio/intellij/ui/FiberDumpPanel.scala
+++ b/src/main/scala/zio/intellij/ui/FiberDumpPanel.scala
@@ -1,0 +1,223 @@
+package zio.intellij.ui
+
+import java.awt.BorderLayout
+import java.awt.datatransfer.StringSelection
+
+import com.intellij.execution.impl.ConsoleViewImpl
+import com.intellij.execution.ui.{ConsoleView, ConsoleViewContentType}
+import com.intellij.icons.AllIcons
+import com.intellij.notification.NotificationGroup
+import com.intellij.openapi.actionSystem._
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.{DumbAware, DumbAwareAction, Project}
+import com.intellij.openapi.ui.{MessageType, Splitter}
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.wm.{IdeFocusManager, ToolWindowId}
+import com.intellij.ui._
+import com.intellij.ui.components.JBList
+import com.intellij.util.PlatformIcons
+import com.intellij.util.ui.UIUtil
+import javax.swing._
+import javax.swing.event.{DocumentEvent, ListSelectionEvent}
+import zio.intellij.icons
+import zio.intellij.ide.FiberDumpToFileExporter
+import zio.intellij.ui.FiberDumpPanel.getFiberStatusIcon
+import zio.intellij.utils.jdi.fiber.model.{FiberInfo, FiberStatus}
+
+/**
+ * This class was copied from the intellij-community project and modified
+ *
+ * https://github.com/JetBrains/intellij-community/blob/48036571856fa3482e394e9bec2a33f9876871b0/java/java-impl/src/com/intellij/unscramble/ThreadDumpPanel.java#L54
+ */
+class FiberDumpPanel(
+  project: Project,
+  consoleView: ConsoleView,
+  toolbarActions: DefaultActionGroup,
+  private var fiberDump: List[FiberInfo]
+) extends JPanel(new BorderLayout())
+    with DataProvider {
+
+  private val filterField = new SearchTextField
+  filterField.addDocumentListener(new DocumentAdapter() {
+    override protected def textChanged(e: DocumentEvent): Unit = updateFiberList()
+  })
+  private val filterPanel = new JPanel(new BorderLayout())
+  filterPanel.add(new JLabel("Filter:"), BorderLayout.WEST)
+  filterPanel.add(filterField)
+  filterPanel.setVisible(false)
+
+  private val fibers = new JBList[FiberInfo](new DefaultListModel[FiberInfo])
+  fibers.setCellRenderer(new FiberListCellRenderer)
+  fibers.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+  fibers.addListSelectionListener { (_: ListSelectionEvent) =>
+    val index = fibers.getSelectedIndex
+    if (index >= 0) {
+      val selection = fibers.getModel.getElementAt(index)
+      FiberDumpPanel.printTrace(consoleView, Option(selection))
+    } else FiberDumpPanel.printTrace(consoleView, None)
+    fibers.repaint()
+  }
+
+  toolbarActions.addAction(new FilterAction)
+  toolbarActions.addAction(new CopyFiberDumpToClipboardAction)
+  toolbarActions.addAction(new SortFibersAction)
+  toolbarActions.addAction(ActionManager.getInstance.getAction(IdeActions.ACTION_EXPORT_TO_TEXT_FILE))
+
+  private val toolbar = ActionManager.getInstance.createActionToolbar("FiberDump", toolbarActions, false)
+  toolbar.setTargetComponent(consoleView.getComponent)
+  add(toolbar.getComponent, BorderLayout.WEST)
+
+  private val leftPanel = new JPanel(new BorderLayout())
+  leftPanel.add(filterPanel, BorderLayout.NORTH)
+  leftPanel.add(ScrollPaneFactory.createScrollPane(fibers, SideBorder.LEFT | SideBorder.RIGHT), BorderLayout.CENTER)
+
+  val splitter = new Splitter(false, 0.3f)
+  splitter.setFirstComponent(leftPanel)
+  splitter.setSecondComponent(consoleView.getComponent)
+  add(splitter, BorderLayout.CENTER)
+
+  updateFiberList()
+
+  override def getData(dataId: String): AnyRef =
+    if (PlatformDataKeys.EXPORTER_TO_TEXT_FILE.is(dataId)) new FiberDumpToFileExporter(project, fiberDump)
+    else null
+
+  private def updateFiberList(): Unit = {
+    val text      = if (filterPanel.isVisible) filterField.getText else ""
+    val selection = fibers.getSelectedValue
+    val model     = fibers.getModel.asInstanceOf[DefaultListModel[FiberInfo]]
+    model.clear()
+
+    val selectedIndex =
+      if (text.isEmpty) {
+        fiberDump.foreach(model.addElement)
+        0
+      } else {
+        fiberDump.zipWithIndex.foldLeft(0) {
+          case (acc, (dump, dumpIdx)) =>
+            val renderedFiberInfo = FiberDumpRenderer.renderFiberInfo(dump)
+            if (StringUtil.containsIgnoreCase(renderedFiberInfo, text)) {
+              model.addElement(dump)
+              if (selection == dump) dumpIdx else acc
+            } else acc
+        }
+      }
+
+    if (!model.isEmpty) {
+      fibers.setSelectedIndex(selectedIndex)
+    }
+    fibers.revalidate()
+    fibers.repaint()
+  }
+
+  private class FilterAction
+      extends ToggleAction("Filter", "Show only fiber traces containing a specific string", AllIcons.General.Filter)
+      with DumbAware {
+    override def isSelected(event: AnActionEvent): Boolean = filterPanel.isVisible
+
+    override def setSelected(event: AnActionEvent, state: Boolean): Unit = {
+      filterPanel.setVisible(state)
+      if (state) {
+        IdeFocusManager.getInstance(AnAction.getEventProject(event)).requestFocus(filterField, true)
+        filterField.selectText()
+      }
+      updateFiberList()
+    }
+  }
+
+  private class CopyFiberDumpToClipboardAction
+      extends DumbAwareAction("Copy to Clipboard", "Copy whole thread dump to clipboard", PlatformIcons.COPY_ICON) {
+    private val GROUP = NotificationGroup.toolWindowGroup("Analyze fiber dump", ToolWindowId.RUN, false)
+
+    override def actionPerformed(e: AnActionEvent): Unit = {
+      val separator = "\n\n"
+      val buf       = new StringBuilder
+      buf.append("Full fiber dump").append(separator)
+      fiberDump.foreach(info => buf.append(FiberDumpRenderer.renderFiberInfo(info)).append(separator))
+      CopyPasteManager.getInstance().setContents(new StringSelection(buf.toString()))
+
+      GROUP.createNotification("Full fiber dump was successfully copied to clipboard", MessageType.INFO).notify(project)
+    }
+  }
+
+  private class SortFibersAction extends DumbAwareAction {
+    private val BY_STATUS: Ordering[FiberInfo] = Ordering[FiberStatus].on[FiberInfo](_.status)
+    private val BY_ID: Ordering[FiberInfo]     = Ordering[Long].on[FiberInfo](_.id.seqNumber)
+    private val BY_NAME: Ordering[FiberInfo]   = Ordering[Option[String]].on[FiberInfo](_.name)
+
+    private var ORDERING: Ordering[FiberInfo] = BY_STATUS
+
+    override def actionPerformed(event: AnActionEvent): Unit = {
+      fiberDump = fiberDump.sorted(ORDERING)
+      updateFiberList()
+      toggleOrdering()
+      update(event)
+    }
+
+    override def update(event: AnActionEvent): Unit = {
+      event.getPresentation.setIcon(getIcon)
+      event.getPresentation.setText(getLabel)
+    }
+
+    private def toggleOrdering(): Unit =
+      ORDERING = ORDERING match {
+        case BY_STATUS => BY_ID
+        case BY_ID     => BY_NAME
+        case _         => BY_STATUS
+      }
+
+    private def getIcon: Icon = ORDERING match {
+      case BY_STATUS => AllIcons.ObjectBrowser.SortByType
+      case BY_ID     => icons.SortByIdIcon
+      case _         => AllIcons.ObjectBrowser.Sorted
+    }
+
+    private def getLabel: String = ORDERING match {
+      case BY_STATUS => FiberDumpPanel.SORT_BY_STATUS_LABEL
+      case BY_ID     => FiberDumpPanel.SORT_BY_ID_LABEL
+      case _         => FiberDumpPanel.SORT_BY_NAME_LABEL
+    }
+  }
+
+}
+
+private class FiberListCellRenderer extends ColoredListCellRenderer[FiberInfo] {
+
+  override def customizeCellRenderer(
+    list: JList[_ <: FiberInfo],
+    fiber: FiberInfo,
+    index: Int,
+    selected: Boolean,
+    hasFocus: Boolean
+  ): Unit = {
+    setIcon(getFiberStatusIcon(fiber))
+    if (!selected) setBackground(UIUtil.getListBackground)
+    append(s"${fiber.renderName} (${fiber.status.name})")
+  }
+}
+
+object FiberDumpPanel {
+  val SORT_BY_STATUS_LABEL = "Sort fibers by status"
+  val SORT_BY_NAME_LABEL   = "Sort fibers by name"
+  val SORT_BY_ID_LABEL     = "Sort fibers by id"
+
+  def getFiberStatusIcon(fiber: FiberInfo): Icon = fiber.status match {
+    case _: FiberStatus.Running   => AllIcons.Actions.Execute
+    case _: FiberStatus.Suspended => AllIcons.Actions.Pause
+    case _: FiberStatus.Finishing => AllIcons.Actions.Exit
+    case FiberStatus.Done         => AllIcons.Actions.Cancel
+  }
+
+  def printTrace(consoleView: ConsoleView, fiberInfo: Option[FiberInfo]): Unit = {
+    ApplicationManager.getApplication.assertIsDispatchThread()
+    val consoleText = consoleView.asInstanceOf[ConsoleViewImpl].getText
+    val text        = fiberInfo.fold("")(FiberDumpRenderer.renderFiberInfo)
+    if (text != consoleText) {
+      consoleView.clear()
+      consoleView.print(text, ConsoleViewContentType.ERROR_OUTPUT)
+      consoleView.scrollTo(0)
+    }
+  }
+
+}

--- a/src/main/scala/zio/intellij/ui/FiberDumpRenderer.scala
+++ b/src/main/scala/zio/intellij/ui/FiberDumpRenderer.scala
@@ -1,0 +1,35 @@
+package zio.intellij.ui
+
+import zio.intellij.utils.jdi.fiber.model.{FiberInfo, FiberStatus}
+
+object FiberDumpRenderer {
+
+  /**
+   * This function was copied from the zio project and modified
+   *
+   * https://github.com/zio/zio/blob/e9124af60becf2cab93aa92cdab392975fb94664/core/shared/src/main/scala/zio/internal/FiberRenderer.scala#L19
+   */
+  def renderFiberInfo(fiberInfo: FiberInfo): String = {
+    val name = fiberInfo.name.fold("")(name => "\"" + name + "\"")
+    val waitMsg = fiberInfo.status match {
+      case FiberStatus.Suspended(_, _, blockingOn, _) if blockingOn.nonEmpty =>
+        "waiting on " + blockingOn.map(id => s"#${id.seqNumber}").mkString(", ")
+      case _ => ""
+    }
+    val statusMsg = fiberInfo.status match {
+      case FiberStatus.Done         => "Done"
+      case FiberStatus.Finishing(b) => "Finishing" + (if (b) "(interrupting)" else "")
+      case FiberStatus.Running(b)   => "Running" + (if (b) "(interrupting)" else "")
+      case FiberStatus.Suspended(interruptible, epoch, _, asyncTrace) =>
+        val in = if (interruptible) "interruptible" else "uninterruptible"
+        val ep = s"$epoch asyncs"
+        val as = asyncTrace.map(_.prettyPrint).mkString(" ")
+        s"Suspended($in, $ep, $as)"
+    }
+
+    s"""$name#${fiberInfo.id.seqNumber} $waitMsg
+       |   Status: $statusMsg
+       |${fiberInfo.trace.fold("")(_.prettyPrint)}
+       |""".stripMargin
+  }
+}

--- a/src/main/scala/zio/intellij/utils/Version.scala
+++ b/src/main/scala/zio/intellij/utils/Version.scala
@@ -1,0 +1,79 @@
+package zio.intellij.utils
+
+import zio.intellij.utils.Version._
+
+import scala.util.matching.Regex
+
+sealed abstract case class Version private (major: Major, minor: Minor, patch: Patch, rcVersion: Option[RCVersion])
+    extends Ordered[Version] {
+  def === (that: Version): Boolean = Version.versionOrdering.equiv(this, that)
+
+  override def compare(that: Version): Int =
+    Version.versionOrdering.compare(this, that)
+}
+
+object Version {
+
+  val versionOrdering: Ordering[Version] =
+    Ordering[(Major, Minor, Patch)]
+      .on[Version](v => (v.major, v.minor, v.patch))
+      // 1.0.0-RC1 should be less than 1.0.0
+      .orElse(Ordering.Option(Ordering[RCVersion].reverse).reverse.on[Version](_.rcVersion))
+
+  final case class Major(value: Int) extends Ordered[Major] {
+    override def compare(that: Major): Int = this.value.compare(that.value)
+  }
+
+  final case class Minor(value: Int) extends Ordered[Minor] {
+    override def compare(that: Minor): Int = this.value.compare(that.value)
+  }
+
+  final case class Patch(value: Int) extends Ordered[Patch] {
+    override def compare(that: Patch): Int = this.value.compare(that.value)
+  }
+
+  final case class RCVersion(major: RCMajor, minor: Option[RCMinor]) extends Ordered[RCVersion] {
+    override def compare(that: RCVersion): Int = RCVersion.ordering.compare(this, that)
+  }
+
+  object RCVersion {
+
+    val ordering: Ordering[RCVersion] =
+      // For now, we don't care if RC1-0 is greater thar RC1
+      // But RC1-2 should be greater than RC1
+      Ordering[(RCMajor, Option[RCMinor])].on[RCVersion](v => (v.major, v.minor))
+  }
+
+  final case class RCMajor(value: Int) extends Ordered[RCMajor] {
+    override def compare(that: RCMajor): Int = this.value.compare(that.value)
+  }
+
+  final case class RCMinor(value: Int) extends Ordered[RCMinor] {
+    override def compare(that: RCMinor): Int = this.value.compare(that.value)
+  }
+
+  val versionRegex: Regex = """(\d+).(\d+).(\d+)(?:(?:-(?:(?:RC)|(?:rc))(\d+))(?:-(\d+))?)?""".r
+
+  def parse(str: String): Option[Version] = str match {
+    case versionRegex(majorStr, minorStr, patchStr, rcMajorStr, rcMinorStr) =>
+      val major        = Major(majorStr.toInt)
+      val minor        = Minor(minorStr.toInt)
+      val patch        = Patch(patchStr.toInt)
+      val rcMajorOpt   = Option(rcMajorStr).map(rcMajorStr => RCMajor(rcMajorStr.toInt))
+      val rcMinorOpt   = Option(rcMinorStr).map(rcMinorStr => RCMinor(rcMinorStr.toInt))
+      val rcVersionOpt = rcMajorOpt.map(RCVersion(_, rcMinorOpt))
+
+      Some(new Version(major, minor, patch, rcVersionOpt) {})
+    case _ => None
+  }
+
+  def parseUnsafe(str: String): Version =
+    parse(str).getOrElse(throw new IllegalArgumentException(s"Could not parse version: $str"))
+
+  object ZIO {
+    val RC18: Version = Version.parseUnsafe("1.0.0-RC18")
+    val RC19: Version = Version.parseUnsafe("1.0.0-RC19")
+    val RC21: Version = Version.parseUnsafe("1.0.0-RC21")
+  }
+
+}

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberId.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberId.scala
@@ -1,0 +1,11 @@
+package zio.intellij.utils.jdi.fiber.model
+
+/**
+ * This class was copied from the zio project
+ *
+ * https://github.com/zio/zio/blob/e9124af60becf2cab93aa92cdab392975fb94664/core/shared/src/main/scala/zio/Fiber.scala#L510
+ *
+ * The identity of a Fiber, described by the time it began life, and a
+ * monotonically increasing sequence number generated from an atomic counter.
+ */
+final case class FiberId(startTimeMillis: Long, seqNumber: Long) extends Serializable

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberInfo.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberInfo.scala
@@ -1,0 +1,5 @@
+package zio.intellij.utils.jdi.fiber.model
+
+final case class FiberInfo(id: FiberId, name: Option[String], status: FiberStatus, trace: Option[ZTrace]) {
+  val renderName: String = s"${name.getOrElse("unnamed")}-${id.startTimeMillis}@${id.seqNumber}"
+}

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberStatus.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/model/FiberStatus.scala
@@ -1,0 +1,46 @@
+package zio.intellij.utils.jdi.fiber.model
+
+/**
+ * This trait was copied from the zio project and modified
+ *
+ * https://github.com/zio/zio/blob/e9124af60becf2cab93aa92cdab392975fb94664/core/shared/src/main/scala/zio/Fiber.scala#L519
+ */
+sealed trait FiberStatus extends Product with Serializable { self =>
+  import FiberStatus._
+
+  val name: String = self match {
+    case Done         => "Done"
+    case _: Running   => "Running"
+    case _: Finishing => "Finishing"
+    case _: Suspended => "Suspended"
+  }
+}
+
+object FiberStatus {
+  private val classPrefix   = "zio.Fiber$Status$"
+  val RunningName: String   = classPrefix + "Running"
+  val SuspendedName: String = classPrefix + "Suspended"
+  val FinishingName: String = classPrefix + "Finishing"
+  val DoneName: String      = classPrefix + "Done$"
+
+  implicit val ordering: Ordering[FiberStatus] = {
+    case (x, y) if x eq y  => 0
+    case (_: Running, _)   => -1
+    case (_, _: Running)   => 1
+    case (_: Suspended, _) => -1
+    case (_, _: Suspended) => 1
+    case (_: Finishing, _) => -1
+    case (_, _: Finishing) => 1
+  }
+
+  case object Done                                  extends FiberStatus
+  final case class Finishing(interrupting: Boolean) extends FiberStatus
+  final case class Running(interrupting: Boolean)   extends FiberStatus
+
+  final case class Suspended(
+    interruptible: Boolean,
+    epoch: Long,
+    blockingOn: List[FiberId],
+    asyncTrace: Option[ZTraceElement]
+  ) extends FiberStatus
+}

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/model/ZTrace.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/model/ZTrace.scala
@@ -1,0 +1,38 @@
+package zio.intellij.utils.jdi.fiber.model
+
+/**
+ * This class was copied from the zio project and modified
+ *
+ * https://github.com/zio/zio/blob/e9124af60becf2cab93aa92cdab392975fb94664/core/shared/src/main/scala/zio/ZTrace.scala#L23
+ */
+final case class ZTrace(
+  fiberId: FiberId,
+  executionTrace: List[ZTraceElement],
+  stackTrace: List[ZTraceElement],
+  parent: Option[FiberId]
+) {
+
+  def prettyPrint: String = {
+    val hasExecTrace  = executionTrace.nonEmpty
+    val hasStackTrace = stackTrace.nonEmpty
+
+    val stackPrint =
+      if (hasStackTrace)
+        s"Fiber#${fiberId.seqNumber} was supposed to continue to:" ::
+          stackTrace.map(loc => s"  a future continuation at " + loc.prettyPrint)
+      else
+        s"Fiber#${fiberId.seqNumber} was supposed to continue to: <empty trace>" :: Nil
+
+    val execPrint =
+      if (hasExecTrace)
+        s"Fiber#${fiberId.seqNumber} execution trace:" ::
+          executionTrace.map(loc => "  at " + loc.prettyPrint)
+      else s"Fiber#${fiberId.seqNumber} ZIO Execution trace: <empty trace>" :: Nil
+
+    val ancestry =
+      parent.map(parentId => s"Fiber#${fiberId.seqNumber} was spawned by: #${parentId.seqNumber}" :: Nil).getOrElse(Nil)
+
+    (stackPrint ++ execPrint ++ ancestry).mkString("\n")
+  }
+
+}

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/model/ZTraceElement.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/model/ZTraceElement.scala
@@ -1,0 +1,22 @@
+package zio.intellij.utils.jdi.fiber.model
+
+/**
+ * This class was copied from the zio project
+ *
+ * https://github.com/zio/zio/blob/e9124af60becf2cab93aa92cdab392975fb94664/stacktracer/shared/src/main/scala/zio/internal/stacktracer/ZTraceElement.scala#L19
+ */
+sealed abstract class ZTraceElement extends Product with Serializable {
+  def prettyPrint: String
+}
+
+object ZTraceElement {
+
+  final case class NoLocation(error: String) extends ZTraceElement {
+    def prettyPrint = s"<couldn't get location, error: $error>"
+  }
+
+  final case class SourceLocation(file: String, clazz: String, method: String, line: Int) extends ZTraceElement {
+    def toStackTraceElement: StackTraceElement = new StackTraceElement(clazz, method, file, line)
+    def prettyPrint: String                    = toStackTraceElement.toString
+  }
+}

--- a/src/main/scala/zio/intellij/utils/jdi/fiber/package.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/fiber/package.scala
@@ -1,0 +1,172 @@
+package zio.intellij.utils.jdi
+
+import com.sun.jdi.{ObjectReference, Value}
+import org.jetbrains.plugins.scala.project.ScalaLanguageLevel
+import zio.intellij.utils.Version
+import zio.intellij.utils.jdi.fiber.model.ZTraceElement.{NoLocation, SourceLocation}
+import zio.intellij.utils.jdi.fiber.model._
+
+package object fiber {
+
+  final case class RawFiberInfo(info: FiberInfo, children: List[Value])
+
+  def convertFiberInfoWithChildren(
+    value: Value
+  )(implicit zioVersion: Version, languageLevel: ScalaLanguageLevel): Option[RawFiberInfo] = value match {
+    case dump: ObjectReference if dump.`type`().name() == DumpRef.DumpName =>
+      for {
+        fiberId   <- convertFiberId(getFieldValue(dump, DumpRef.FiberIdField))
+        fiberName = convertOption(getFieldValue(dump, DumpRef.FiberNameField))(convertStringValue)
+        status    <- convertFiberStatus(getFieldValue(dump, DumpRef.StatusField))
+        if status != FiberStatus.Done
+        // in versions < rc19 there are no children and trace is not optional
+        (children, trace) = if (zioVersion < Version.ZIO.RC19) {
+          (Nil, convertZTrace(fiberId)(getFieldValue(dump, DumpRef.TraceField)))
+        } else {
+          val children = convertScalaSeq(getFieldValue(dump, DumpRef.ChildrenField))
+          val trace    = convertOption(getFieldValue(dump, DumpRef.TraceField))(convertZTrace(fiberId))
+          (children, trace)
+        }
+      } yield RawFiberInfo(FiberInfo(fiberId, fiberName, status, trace), children)
+    case _ => None
+  }
+
+  def convertFiberId(value: Value): Option[FiberId] = value match {
+    case fiberId: ObjectReference if fiberId.`type`().name() == FiberIdRef.FiberIdName =>
+      for {
+        startTimeMillis <- convertLongValue(getFieldValue(fiberId, FiberIdRef.StartTimeMillisField))
+        seqNumber       <- convertLongValue(getFieldValue(fiberId, FiberIdRef.SeqNumberField))
+      } yield FiberId(startTimeMillis = startTimeMillis, seqNumber = seqNumber)
+    case _ => None
+  }
+
+  def convertFiberStatus(value: Value)(implicit languageLevel: ScalaLanguageLevel): Option[FiberStatus] = value match {
+    case status: ObjectReference =>
+      status.`type`().name() match {
+        case FiberStatus.DoneName => Some(FiberStatus.Done)
+        case FiberStatus.RunningName =>
+          val interrupting = convertBooleanValue(getFieldValue(status, FiberStatusRef.RunningRef.InterruptingField))
+          interrupting.map(FiberStatus.Running)
+        case FiberStatus.FinishingName =>
+          val interrupting = convertBooleanValue(getFieldValue(status, FiberStatusRef.FinishingRef.InterruptingField))
+          interrupting.map(FiberStatus.Finishing)
+        case FiberStatus.SuspendedName =>
+          for {
+            interruptible <- convertBooleanValue(getFieldValue(status, FiberStatusRef.SuspendedRef.InterruptibleField))
+            epoch         <- convertLongValue(getFieldValue(status, FiberStatusRef.SuspendedRef.EpochField))
+            blockingOn = convertScalaSeq(getFieldValue(status, FiberStatusRef.SuspendedRef.BlockingOnField))
+              .flatMap(convertFiberId)
+            asyncTrace = convertOption(getFieldValue(status, FiberStatusRef.SuspendedRef.AsyncTraceField))(
+              convertZTraceElement
+            )
+          } yield FiberStatus.Suspended(interruptible, epoch, blockingOn, asyncTrace)
+        case _ => None
+      }
+    case _ => None
+  }
+
+  def convertZTraceElement(value: Value): Option[ZTraceElement] = value match {
+    case srcLoc: ObjectReference if srcLoc.`type`().name() == ZTraceElementRef.SourceLocationName =>
+      for {
+        file   <- convertStringValue(getFieldValue(srcLoc, ZTraceElementRef.SourceLocationRef.FileField))
+        clazz  <- convertStringValue(getFieldValue(srcLoc, ZTraceElementRef.SourceLocationRef.ClazzField))
+        method <- convertStringValue(getFieldValue(srcLoc, ZTraceElementRef.SourceLocationRef.MethodField))
+        line   <- convertIntegerValue(getFieldValue(srcLoc, ZTraceElementRef.SourceLocationRef.LineField))
+      } yield SourceLocation(file, clazz, method, line)
+    case noLoc: ObjectReference if noLoc.`type`().name() == ZTraceElementRef.NoLocationName =>
+      val error = convertStringValue(getFieldValue(noLoc, ZTraceElementRef.NoLocationRef.ErrorField))
+      error.map(NoLocation)
+    case _ => None
+  }
+
+  def convertZTrace(fiberId: FiberId)(value: Value)(implicit languageLevel: ScalaLanguageLevel): Option[ZTrace] =
+    value match {
+      case trace: ObjectReference if trace.`type`().name() == ZTraceRef.ZTraceName =>
+        val executionTrace =
+          convertScalaSeq(getFieldValue(trace, ZTraceRef.ExecutionTraceField))
+            .flatMap(convertZTraceElement)
+        val stackTrace =
+          convertScalaSeq(getFieldValue(trace, ZTraceRef.StackTraceField))
+            .flatMap(convertZTraceElement)
+        val parent = convertOption(getFieldValue(trace, ZTraceRef.ParentTraceField)) {
+          case parentTrace: ObjectReference =>
+            convertFiberId(getFieldValue(parentTrace, ZTraceRef.FiberIdField))
+          case _ => None
+        }
+        Some(ZTrace(fiberId, executionTrace, stackTrace, parent))
+      case _ => None
+    }
+
+  private[jdi] object DumpRef {
+    // classes
+    val DumpName = "zio.Fiber$Dump"
+
+    // fields
+    val FiberIdField   = "fiberId"
+    val FiberNameField = "fiberName"
+    val StatusField    = "status"
+    val ChildrenField  = "children"
+    val TraceField     = "trace"
+  }
+
+  private[jdi] object FiberIdRef {
+    // classes
+    val FiberIdName = "zio.Fiber$Id"
+
+    // fields
+    val StartTimeMillisField = "startTimeMillis"
+    val SeqNumberField       = "seqNumber"
+  }
+
+  private[jdi] object FiberStatusRef {
+
+    object RunningRef {
+      // fields
+      val InterruptingField = "interrupting"
+    }
+
+    object FinishingRef {
+      // fields
+      val InterruptingField = "interrupting"
+    }
+
+    object SuspendedRef {
+      // fields
+      val InterruptibleField = "interruptible"
+      val EpochField         = "epoch"
+      val BlockingOnField    = "blockingOn"
+      val AsyncTraceField    = "asyncTrace"
+    }
+  }
+
+  private[jdi] object ZTraceElementRef {
+    // classes
+    val SourceLocationName = "zio.internal.stacktracer.ZTraceElement$SourceLocation"
+    val NoLocationName     = "zio.internal.stacktracer.ZTraceElement$NoLocation"
+
+    object SourceLocationRef {
+      // fields
+      val FileField   = "file"
+      val ClazzField  = "clazz"
+      val MethodField = "method"
+      val LineField   = "line"
+    }
+
+    object NoLocationRef {
+      // fields
+      val ErrorField = "error"
+    }
+  }
+
+  private[jdi] object ZTraceRef {
+    // classes
+    val ZTraceName = "zio.ZTrace"
+
+    // fields
+    val ExecutionTraceField = "executionTrace"
+    val StackTraceField     = "stackTrace"
+    val ParentTraceField    = "parentTrace"
+    val FiberIdField        = "fiberId"
+  }
+
+}

--- a/src/main/scala/zio/intellij/utils/jdi/package.scala
+++ b/src/main/scala/zio/intellij/utils/jdi/package.scala
@@ -1,0 +1,79 @@
+package zio.intellij.utils
+
+import com.sun.jdi._
+import org.jetbrains.plugins.scala.project.ScalaLanguageLevel
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+package object jdi {
+
+  def getFieldValue(obj: ObjectReference, fieldName: String): Value =
+    obj.getValue(obj.referenceType().fieldByName(fieldName))
+
+  def convertBooleanValue(value: Value): Option[Boolean] = value match {
+    case b: BooleanValue => Some(b.value())
+    case _               => None
+  }
+
+  def convertIntegerValue(value: Value): Option[Int] = value match {
+    case l: IntegerValue => Some(l.value())
+    case _               => None
+  }
+
+  def convertLongValue(value: Value): Option[Long] = value match {
+    case l: LongValue => Some(l.value())
+    case _            => None
+  }
+
+  def convertStringValue(value: Value): Option[String] = value match {
+    case string: StringReference =>
+      Some(string.value())
+    case _ => None
+  }
+
+  def convertOption[T](optionValue: Value)(inner: Value => Option[T]): Option[T] =
+    optionValue match {
+      case o: ObjectReference if o.`type`().name() == OptionRef.SomeName =>
+        val value = getFieldValue(o, OptionRef.ValueField)
+        inner(value)
+      case _ => None
+    }
+
+  def convertScalaSeq(value: Value)(implicit languageLevel: ScalaLanguageLevel): List[Value] = {
+    @tailrec
+    def convertList(value: Value, acc: List[Value]): List[Value] = value match {
+      case obj: ObjectReference if obj.`type`().name() == ListRef.ConsName =>
+        val head = getFieldValue(obj, ListRef.HeadField)
+        val tail = getFieldValue(obj, ListRef.TailField)
+        convertList(tail, head :: acc)
+      case _ => acc.reverse
+    }
+
+    value match {
+      case obj: ObjectReference if obj.`type`().name() == ListRef.ConsName => convertList(value, Nil)
+      case array: ArrayReference                                           => array.getValues.asScala.toList
+      case _                                                               => Nil
+    }
+  }
+
+  private[jdi] object OptionRef {
+    // classes
+    val SomeName: String = "scala.Some"
+
+    // fields
+    val ValueField: String = "value"
+  }
+
+  private[jdi] object ListRef {
+    // classes
+    val ConsName = "scala.collection.immutable.$colon$colon"
+
+    // fields
+    val HeadField = "head"
+
+    def TailField(implicit languageLevel: ScalaLanguageLevel): String =
+      if (languageLevel < ScalaLanguageLevel.Scala_2_13) "tl" else "next"
+  }
+
+}

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -23,4 +23,27 @@ package object utils {
       ReferencesSearch.search(element, element.getUseScope).findFirst() != null
     }
 
+  // CompositeOrdering is taken from https://stackoverflow.com/a/14696410
+  final class CompositeOrdering[T](val ord1: Ordering[T], val ord2: Ordering[T]) extends Ordering[T] {
+
+    def compare(x: T, y: T): Int = {
+      val comp = ord1.compare(x, y)
+      if (comp != 0) comp else ord2.compare(x, y)
+    }
+  }
+
+  object CompositeOrdering {
+    def apply[T](orderings: Ordering[T]*): Ordering[T] = orderings.reduceLeft(_.orElse(_))
+  }
+
+  implicit final class OrderingOps[T](private val ord: Ordering[T]) extends AnyVal {
+    def orElse(ord2: Ordering[T]) = new CompositeOrdering[T](ord, ord2)
+  }
+
+  def trimAfterSuffix(str: String, suffix: String): String = {
+    val idx = str.lastIndexOf(suffix)
+    if (idx < 0) str
+    else str.substring(0, idx + suffix.length)
+  }
+
 }

--- a/src/test/scala/zio/intellij/utils/VersionComparisonTest.scala
+++ b/src/test/scala/zio/intellij/utils/VersionComparisonTest.scala
@@ -1,0 +1,62 @@
+package zio.intellij.utils
+
+import junit.framework.TestCase
+import org.junit.Assert.{assertEquals, assertTrue}
+
+class VersionComparisonTest extends TestCase {
+
+  def test_equality(): Unit = {
+    assertTrue(Version.parse("1.0.0").get === Version.parseUnsafe("1.0.0"))
+    assertTrue(Version.parse("1.0.0").get >= Version.parseUnsafe("1.0.0"))
+    assertTrue(Version.parse("1.0.0-RC1").get >= Version.parseUnsafe("1.0.0-RC1"))
+    assertTrue(Version.parse("1.0.0-RC1-2").get <= Version.parseUnsafe("1.0.0-RC1-2"))
+  }
+
+  def test_gt(): Unit = {
+    assertTrue(Version.parseUnsafe("1.0.0") > Version.parseUnsafe("0.0.0"))
+    assertTrue(Version.parseUnsafe("1.0.0") > Version.parseUnsafe("0.0.1"))
+    assertTrue(Version.parseUnsafe("1.0.0") > Version.parseUnsafe("0.1.0"))
+    assertTrue(Version.parseUnsafe("1.2.0") > Version.parseUnsafe("1.1.0"))
+    assertTrue(Version.parseUnsafe("1.2.3") > Version.parseUnsafe("1.2.2"))
+  }
+
+  def test_lt(): Unit = {
+    assertTrue(Version.parseUnsafe("0.0.0") < Version.parseUnsafe("1.0.0"))
+    assertTrue(Version.parseUnsafe("0.0.1") < Version.parseUnsafe("1.0.0"))
+    assertTrue(Version.parseUnsafe("0.1.0") < Version.parseUnsafe("1.0.0"))
+    assertTrue(Version.parseUnsafe("1.1.0") < Version.parseUnsafe("1.2.0"))
+    assertTrue(Version.parseUnsafe("1.2.2") < Version.parseUnsafe("1.2.3"))
+  }
+
+  def test_rc_qt(): Unit = {
+    assertTrue(Version.parseUnsafe("1.2.3-RC2") > Version.parseUnsafe("1.2.3-RC1"))
+    assertTrue(Version.parseUnsafe("1.2.3-RC2-2") > Version.parseUnsafe("1.2.3-RC2-1"))
+  }
+
+  def test_rc_lt(): Unit = {
+    assertTrue(Version.parseUnsafe("1.2.3-RC1") < Version.parseUnsafe("1.2.3-RC2"))
+    assertTrue(Version.parseUnsafe("1.2.3-RC2-1") < Version.parseUnsafe("1.2.3-RC2-2"))
+  }
+
+  def test_rc_with_minor_part_should_be_greater_than_rc_without_minor(): Unit = {
+    assertTrue(Version.parseUnsafe("1.2.3-RC2-2") > Version.parseUnsafe("1.2.3-RC2"))
+    assertTrue(Version.parseUnsafe("1.2.3-RC2") < Version.parseUnsafe("1.2.3-RC2-2"))
+  }
+
+  def test_version_without_rc_should_be_greater_than_version_with_rc(): Unit = {
+    assertTrue(Version.parseUnsafe("1.2.3") > Version.parseUnsafe("1.2.3-RC21"))
+    assertTrue(Version.parseUnsafe("1.2.3") > Version.parseUnsafe("1.2.3-RC21-1"))
+
+    assertTrue(Version.parseUnsafe("1.2.3-RC21") < Version.parseUnsafe("1.2.3"))
+    assertTrue(Version.parseUnsafe("1.2.3-RC21-1") < Version.parseUnsafe("1.2.3"))
+  }
+
+  def test_sorting_on_zio_versions_from_maven(): Unit = {
+    val versions       = VersionTestUtils.zioVersionsFromMaven.map(Version.parseUnsafe)
+    val sortedVersions = versions.sorted(Version.versionOrdering.reverse)
+    versions.reverse.zip(sortedVersions).foreach {
+      case (v1, v2) => assertEquals(v1, v2)
+    }
+  }
+
+}

--- a/src/test/scala/zio/intellij/utils/VersionParsingTest.scala
+++ b/src/test/scala/zio/intellij/utils/VersionParsingTest.scala
@@ -1,0 +1,81 @@
+package zio.intellij.utils
+
+import junit.framework.TestCase
+import org.junit.Assert.{assertEquals, assertTrue}
+
+class VersionParsingTest extends TestCase {
+
+  private def assertVersion(
+    version: Version,
+    major: Version.Major,
+    minor: Version.Minor,
+    patch: Version.Patch,
+    rcVersion: Option[Version.RCVersion]
+  ): Unit = {
+    assertEquals(version.major, major)
+    assertEquals(version.minor, minor)
+    assertEquals(version.patch, patch)
+    assertEquals(version.rcVersion, rcVersion)
+  }
+
+  def test_should_parse_simple_version(): Unit = {
+    val versionOpt = Version.parse("1.2.3")
+    assertTrue(versionOpt.isDefined)
+    versionOpt.foreach { version =>
+      assertVersion(
+        version,
+        Version.Major(1),
+        Version.Minor(2),
+        Version.Patch(3),
+        None
+      )
+    }
+  }
+
+  def test_should_parse_rc_version(): Unit = {
+    val versionOpt = Version.parse("1.2.3-RC4")
+    assertTrue(versionOpt.isDefined)
+    versionOpt.foreach { version =>
+      assertVersion(
+        version,
+        Version.Major(1),
+        Version.Minor(2),
+        Version.Patch(3),
+        Some(Version.RCVersion(Version.RCMajor(4), None))
+      )
+      assertEquals(version, Version.parseUnsafe("1.2.3-rc4"))
+    }
+  }
+
+  def test_should_parse_rc_version_with_minor_part(): Unit = {
+    val versionOpt = Version.parse("1.2.3-RC4-5")
+    assertTrue(versionOpt.isDefined)
+    versionOpt.foreach { version =>
+      assertVersion(
+        version,
+        Version.Major(1),
+        Version.Minor(2),
+        Version.Patch(3),
+        Some(Version.RCVersion(Version.RCMajor(4), Some(Version.RCMinor(5))))
+      )
+    }
+  }
+
+  def test_should_fail_to_parse_version_without_minor_and_patch(): Unit =
+    assertEquals(Version.parse("1"), None)
+
+  def test_should_fail_to_parse_version_without_patch(): Unit =
+    assertEquals(Version.parse("1.2"), None)
+
+  def test_should_fail_to_parse_version_with_invalid_rc_part(): Unit = {
+    assertEquals(Version.parse("1.2.3-4"), None)
+    assertEquals(Version.parse("1.2.3-RC"), None)
+    assertEquals(Version.parse("1.2.3-RC-"), None)
+    assertEquals(Version.parse("1.2.3-RC-4-"), None)
+  }
+
+  def test_should_parse_versions_from_maven(): Unit =
+    VersionTestUtils.zioVersionsFromMaven
+      .foreach(versionStr => assertTrue(Version.parse(versionStr).isDefined))
+
+}

--- a/src/test/scala/zio/intellij/utils/VersionTestUtils.scala
+++ b/src/test/scala/zio/intellij/utils/VersionTestUtils.scala
@@ -1,0 +1,39 @@
+package zio.intellij.utils
+
+object VersionTestUtils {
+
+  // source: https://repo1.maven.org/maven2/dev/zio/zio_2.11/maven-metadata.xml
+  val zioVersionsFromMaven: Array[String] =
+    """<version>1.0.0-RC6</version>
+      |<version>1.0.0-RC8</version>
+      |<version>1.0.0-RC8-4</version>
+      |<version>1.0.0-RC8-7</version>
+      |<version>1.0.0-RC8-8</version>
+      |<version>1.0.0-RC8-9</version>
+      |<version>1.0.0-RC8-10</version>
+      |<version>1.0.0-RC8-11</version>
+      |<version>1.0.0-RC8-12</version>
+      |<version>1.0.0-RC9</version>
+      |<version>1.0.0-RC9-4</version>
+      |<version>1.0.0-RC10-1</version>
+      |<version>1.0.0-RC11</version>
+      |<version>1.0.0-RC11-1</version>
+      |<version>1.0.0-RC12</version>
+      |<version>1.0.0-RC12-1</version>
+      |<version>1.0.0-RC13</version>
+      |<version>1.0.0-RC14</version>
+      |<version>1.0.0-RC15</version>
+      |<version>1.0.0-RC16</version>
+      |<version>1.0.0-RC17</version>
+      |<version>1.0.0-RC18</version>
+      |<version>1.0.0-RC18-1</version>
+      |<version>1.0.0-RC18-2</version>
+      |<version>1.0.0-RC19</version>
+      |<version>1.0.0-RC19-1</version>
+      |<version>1.0.0-RC19-2</version>
+      |<version>1.0.0-RC20</version>
+      |<version>1.0.0-RC21</version>""".stripMargin
+      .replace("<version>", "")
+      .replace("</version>", "")
+      .split("\n")
+}


### PR DESCRIPTION
Closes #103 

What's in there:
- Dump ZIO Fibers information
- Export to file
- Copy to clipboard
- Filter by text in traces
- Sort by status/id/name
- _Should_ work for non-sbt build systems projects

Known issues:
- Doesn't work with ZIO >= RC21 due to changes in fiber tracking
- Doesn't work with ZIO < RC18 since dumpAll was introduced in RC18
- Sometimes it is way slower than Dump Threads but still acceptable