### PR TITLE
Add simplification from ZIO.foreach to ZIO.foreach_

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -138,6 +138,12 @@
                          shortName="SimplifyFlatmapInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyForeachInspection"
+                         displayName="Simplify .foreach by discarding unused result thus slightly improving performance"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifyForeachInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -201,7 +201,7 @@ package object inspections {
   class TypeReference(typeFQNs: Set[String]) {
 
     def unapply(expr: ScExpression): Option[ScExpression] = expr match {
-      case MethodRepr(_, _, Some(ref), Seq(_)) =>
+      case uncurry1(ref, _) =>
         ref.resolve() match {
           case m: ScMember if typeFQNs.contains(m.containingClass.qualifiedName) => Some(expr)
           case _                                                                 => None
@@ -254,15 +254,11 @@ package object inspections {
           case _: ScReferencePattern | _: ScFunctionDefinition if fromZioLike(expr) => Some((ref, expr))
           case _                                                                    => None
         }
-      case MethodRepr(_, _, Some(ref), Seq(e)) =>
-        ref.resolve() match {
-          case _ if fromZioLike(expr) => Some((ref, e))
-          case _                      => None
-        }
+      case uncurry1(ref, e) if fromZioLike(expr) => Some((ref, e))
       // multiple argument lists
-      case ScMethodCall(ScMethodCall(ref @ ScReferenceExpression(_), Seq(_)), Seq(_)) if fromZioLike(expr) =>
-        Some((ref, expr))
-      case _ => None
+      case uncurry2(ref, _, _) if fromZioLike(expr)    => Some((ref, expr))
+      case uncurry3(ref, _, _, _) if fromZioLike(expr) => Some((ref, expr))
+      case _                                           => None
     }
   }
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
@@ -43,10 +43,8 @@ object CollectAllParNToForeachParNSimplificationType extends SimplificationType 
         .highlightFrom(expr)
 
     expr match {
-      case ScMethodCall(ScMethodCall(ref @ ScReferenceExpression(_), Seq(n)), Seq(iterable `.map` func))
-          if fromZio(expr) && ref.refName == "collectAllParN" =>
-        Some(replacement(n, iterable, func))
-      case _ => None
+      case `ZIO.collectAllParN`(n, iterable `.map` func) => Some(replacement(n, iterable, func))
+      case _                                             => None
     }
   }
 }

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyForeachInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyForeachInspection.scala
@@ -1,0 +1,96 @@
+package zio.intellij.inspections.simplifications
+
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScFor}
+import zio.intellij.inspections._
+import zio.intellij.inspections.zioMethods.`.*>`
+
+class SimplifyForeachInspection
+    extends ZInspection(
+      ForeachForCompSimplificationType,
+      ForeachParForCompSimplificationType,
+      ForeachParNForCompSimplificationType,
+      ForeachChainSimplificationType,
+      ForeachParChainSimplificationType,
+      ForeachParNChainSimplificationType
+    )
+
+sealed abstract class BaseForeachSimplificationType(methodName: String) extends SimplificationType {
+
+  override def hint: String = s"Replace with ZIO.$methodName"
+
+  protected def replacement(expr: ScExpression, iterable: ScExpression, func: ScExpression): Simplification =
+    replace(expr).withText(s"ZIO.$methodName(${iterable.getText})(${func.getText})").highlightFrom(expr)
+}
+
+sealed abstract class BaseForeachParNSimplificationType extends SimplificationType {
+
+  private val methodName = "foreachParN_"
+
+  override def hint: String = s"Replace with ZIO.$methodName"
+
+  def replacement(expr: ScExpression, n: ScExpression, iterable: ScExpression, func: ScExpression): Simplification =
+    replace(expr).withText(s"ZIO.$methodName(${n.getText})(${iterable.getText})(${func.getText})").highlightFrom(expr)
+}
+
+sealed abstract class BaseForeachForCompSimplificationType(
+  methodName: String,
+  methodExtractor: ZIOCurried2StaticMemberReference
+) extends BaseForeachSimplificationType(methodName) {
+
+  override def getSimplifications(expr: ScExpression): Seq[Simplification] =
+    expr match {
+      case ScFor(enumerators, _) =>
+        enumerators.generators.collect {
+          case `_ <- x`(expr @ methodExtractor(iterable, func)) => replacement(expr, iterable, func)
+        }
+      case _ => Nil
+    }
+}
+
+object ForeachForCompSimplificationType
+    extends BaseForeachForCompSimplificationType(methodName = "foreach_", methodExtractor = `ZIO.foreach`)
+
+object ForeachParForCompSimplificationType
+    extends BaseForeachForCompSimplificationType(methodName = "foreachPar_", methodExtractor = `ZIO.foreachPar`)
+
+object ForeachParNForCompSimplificationType extends BaseForeachParNSimplificationType {
+
+  override def getSimplifications(expr: ScExpression): Seq[Simplification] =
+    expr match {
+      case ScFor(enumerators, _) =>
+        enumerators.generators.collect {
+          case `_ <- x`(expr @ `ZIO.foreachParN`(n, iterable, func)) => replacement(expr, n, iterable, func)
+        }
+      case _ => Nil
+    }
+}
+
+sealed abstract class BaseForeachChainSimplificationType(
+  methodName: String,
+  methodExtractor: ZIOCurried2StaticMemberReference
+) extends BaseForeachSimplificationType(methodName) {
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case (expr @ methodExtractor(iterable, func)) `.*>` _         => Some(replacement(expr, iterable, func))
+      case _ `.*>` (expr @ methodExtractor(iterable, func)) `.*>` _ => Some(replacement(expr, iterable, func))
+      case _                                                        => None
+    }
+}
+
+object ForeachChainSimplificationType
+    extends BaseForeachChainSimplificationType(methodName = "foreach_", methodExtractor = `ZIO.foreach`)
+
+object ForeachParChainSimplificationType
+    extends BaseForeachChainSimplificationType(methodName = "foreachPar_", methodExtractor = `ZIO.foreachPar`)
+
+object ForeachParNChainSimplificationType extends BaseForeachParNSimplificationType {
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case (expr @ `ZIO.foreachParN`(n, iterable, func)) `.*>` _         => Some(replacement(expr, n, iterable, func))
+      case _ `.*>` (expr @ `ZIO.foreachParN`(n, iterable, func)) `.*>` _ => Some(replacement(expr, n, iterable, func))
+      case _                                                             => None
+    }
+}

--- a/src/test/scala/zio/inspections/SimplifyForeachInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyForeachInspectionTest.scala
@@ -1,0 +1,130 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil
+import zio.intellij.inspections.simplifications.SimplifyForeachInspection
+
+abstract class SimplifyForeachInspectionTest(
+  methodToReplace: String,
+  methodToReplaceWith: String,
+  isParN: Boolean = false
+) extends ZSimplifyInspectionTest[SimplifyForeachInspection] {
+
+  import EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+
+  private val nParamList = if (isParN) "(n)" else ""
+
+  private val zioMethodToReplace     = s"""URIO.$methodToReplace$nParamList(myIterable)(f)"""
+  private val zioMethodToReplaceWith = s"""ZIO.$methodToReplaceWith$nParamList(myIterable)(f)"""
+
+  override protected val hint: String = s"Replace with ZIO.$methodToReplaceWith"
+
+  def testForCompHighlighting(): Unit =
+    z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- $START$zioMethodToReplace$END
+         |} yield ???""".stripMargin
+    }.assertHighlighted()
+
+  def testForCompReplacement(): Unit = {
+    val text = z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- $zioMethodToReplace
+         |} yield ???""".stripMargin
+    }
+    val result = z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- $zioMethodToReplaceWith
+         |} yield ???""".stripMargin
+    }
+    testQuickFix(text, result, hint)
+  }
+
+  def testNestedForCompHighlighting(): Unit =
+    z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- b
+         |  _ <- $zioMethodToReplaceWith
+         |  _ <- b
+         |  _ <- $START$zioMethodToReplace$END
+         |  _ <- b
+         |} yield ???""".stripMargin
+    }.assertHighlighted()
+
+  def testNestedForCompReplacement(): Unit = {
+    val text = z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- b
+         |  _ <- $zioMethodToReplaceWith
+         |  _ <- b
+         |  _ <- $zioMethodToReplace
+         |  _ <- b
+         |} yield ???""".stripMargin
+    }
+    val result = z {
+      s"""val myIterable: Iterable[String] = ???
+         |for {
+         |  _ <- b
+         |  _ <- $zioMethodToReplaceWith
+         |  _ <- b
+         |  _ <- $zioMethodToReplaceWith
+         |  _ <- b
+         |} yield ???""".stripMargin
+    }
+    testQuickFix(text, result, hint)
+  }
+
+  def testChainHighlighting(): Unit =
+    z {
+      s"""val myIterable: Iterable[String] = ???
+         |$START$zioMethodToReplace$END *> b""".stripMargin
+    }.assertHighlighted()
+
+  def testChainReplacement(): Unit = {
+    val text = z {
+      s"""val myIterable: Iterable[String] = ???
+         |$zioMethodToReplace *> b""".stripMargin
+    }
+    val result = z {
+      s"""val myIterable: Iterable[String] = ???
+         |$zioMethodToReplaceWith *> b""".stripMargin
+    }
+    testQuickFix(text, result, hint)
+  }
+
+  def testNestedChainHighlighting(): Unit =
+    z {
+      s"""val myIterable: Iterable[String] = ???
+         |b <* b *> b *> $START$zioMethodToReplace$END *> b""".stripMargin
+    }.assertHighlighted()
+
+  def testNestedChainReplacement(): Unit = {
+    val text = z {
+      s"""val myIterable: Iterable[String] = ???
+         |b <* b *> b *> $zioMethodToReplace *> b""".stripMargin
+    }
+    val result = z {
+      s"""val myIterable: Iterable[String] = ???
+         |b <* b *> b *> $zioMethodToReplaceWith *> b""".stripMargin
+    }
+    testQuickFix(text, result, hint)
+  }
+
+}
+
+class SimplifyForeachToForeach_Test
+    extends SimplifyForeachInspectionTest(methodToReplace = "foreach", methodToReplaceWith = "foreach_")
+
+class SimplifyForeachParToForeachPar_Test
+    extends SimplifyForeachInspectionTest(methodToReplace = "foreachPar", methodToReplaceWith = "foreachPar_")
+
+class SimplifyForeachParNToForeachParN_Test
+    extends SimplifyForeachInspectionTest(
+      methodToReplace = "foreachParN",
+      methodToReplaceWith = "foreachParN_",
+      isParN = true
+    )

--- a/src/test/scala/zio/inspections/YieldingZIOEffectInspectionTest.scala
+++ b/src/test/scala/zio/inspections/YieldingZIOEffectInspectionTest.scala
@@ -12,6 +12,16 @@ class YieldingZIOEffectInspectionTest extends ZScalaInspectionTest[YieldingZIOEf
                                              |} yield ${START}ZIO.effect(2)$END
                                              |""".stripMargin).assertHighlighted()
 
+  def test_yielding_an_curried_2_effect(): Unit = z(s"""for {
+                                             |  _ <- ZIO.succeed(1)
+                                             |} yield ${START}ZIO.foreach(List(2))(UIO(_))$END
+                                             |""".stripMargin).assertHighlighted()
+
+  def test_yielding_an_curried_3_effect(): Unit = z(s"""for {
+                                                       |  _ <- ZIO.succeed(1)
+                                                       |} yield ${START}ZIO.foreachParN(1)(List(2))(UIO(_))$END
+                                                       |""".stripMargin).assertHighlighted()
+
   def test_yielding_a_val_zio_reference_effect(): Unit = z(s"""val x: UIO[Int] = ???
                                                               |for {
                                                               |  _ <- ZIO.succeed(1)


### PR DESCRIPTION
Suggest replacing:

- `_ <- ZIO.foreach(seq)(f)` with `_ <- ZIO.foreach_(seq)(f)` in for comprehension
- `ZIO.foreach(seq)(f) *> zio` with `ZIO.foreach_(seq)(f) *> zio`

Suggest similar replacements for `ZIO.foreachPar` and `ZIO.foreachParN`.
