### PR TITLE
Detect if guards mistakenly used in for-comprehension on ZIO effect

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -119,7 +119,6 @@
                          shortName="WrapInsteadOfLiftInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
 
-
         <localInspection implementationClass="zio.intellij.inspections.mistakes.YieldingZIOEffectInspection"
                          displayName="Detects if a value returned from the yield part of a for comprehension is explicitly wrapped in a ZIO effect"
                          groupPath="Scala,ZIO" groupName="Inspections"
@@ -142,6 +141,12 @@
                          displayName="Simplify .foreach by discarding unused result thus slightly improving performance"
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyForeachInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.IfGuardInsteadOfWhenInspection"
+                         displayName="Detects if guards mistakenly used in for-comprehension on ZIO effect causing NoSuchElementException."
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="IfGuardInsteadOfWhenInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
 
         <intentionAction>

--- a/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
+++ b/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
@@ -1,0 +1,45 @@
+<html>
+<body>
+Detects if guards mistakenly used in for-comprehension on ZIO effect causing <code>NoSuchElementException</code>.<br/><br/>
+
+The guard expression in the following code snippet will be highlighted:
+<pre>
+for {
+    _ <- myService.executeSomething() if config.somethingShouldBeExecuted
+} yield ???
+</pre>
+<br/>
+Аnd you will also be prompted to fix it using <code>ZIO.when</code>:
+<pre>
+for {
+    _ <- myService.executeSomething().when(config.somethingShouldBeExecuted)
+} yield ???
+</pre>
+<p>
+    <strong>Note</strong>: the highlighting only applies to values that are:
+<ul>
+    <li>Not assigned to a variable, e.g.:
+    <pre>
+    _ <- myService.executeSomething() if config.somethingShouldBeExecuted
+    </pre>
+        will be highlighted, while
+    <pre>
+    executionResult <- myService.executeSomething() if config.somethingShouldBeExecuted
+    </pre>
+        will not.
+    </li>
+    <br/>
+    <li>A ZIO effect, since
+        <pre>
+            effect if condition
+        </pre>
+        desugars to
+        <pre>
+            effect.withFilter(condition)
+        </pre>
+        which fails with NoSuchElementException if condition is false.
+    </li>
+</ul>
+</p>
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/mistakes/IfGuardInsteadOfWhenInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/IfGuardInsteadOfWhenInspection.scala
@@ -1,0 +1,62 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection.{InspectionManager, LocalQuickFix, ProblemDescriptor, ProblemHighlightType}
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.Nls
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnTwoPsiElements, AbstractRegisteredInspection}
+import org.jetbrains.plugins.scala.extensions.PsiElementExt
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScGuard}
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createElementFromText
+import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker
+import zio.intellij.inspections._
+import zio.intellij.inspections.mistakes.IfGuardInsteadOfWhenInspection.createFix
+
+class IfGuardInsteadOfWhenInspection extends AbstractRegisteredInspection {
+
+  override protected def problemDescriptor(
+    element: PsiElement,
+    maybeQuickFix: Option[LocalQuickFix],
+    descriptionTemplate: String,
+    highlightType: ProblemHighlightType
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
+    element match {
+      case `_ <- x`(genExpr)
+          if fromZio(genExpr) && IntentionAvailabilityChecker.checkInspection(this, element.getParent) =>
+        Option(element.getNextSiblingNotWhitespaceComment).collect {
+          case guard @ guard(_) => createFix(genExpr, guard)
+        }
+      case _ => None
+    }
+}
+
+object IfGuardInsteadOfWhenInspection {
+
+  final private class IfGuardQuickFix(generatorExpr: ScExpression, guard: ScGuard)
+      extends AbstractFixOnTwoPsiElements(fixMessage, generatorExpr, guard) {
+
+    override protected def doApplyFix(generatorExpr: ScExpression, guard: ScGuard)(implicit project: Project): Unit = {
+      val replacement = createElementFromText(s"${generatorExpr.getText}.when(${guard.expr.fold("")(_.getText)})")
+      generatorExpr.replace(replacement)
+      guard.delete()
+    }
+  }
+
+  private def createFix(
+    genExpr: ScExpression,
+    guard: ScGuard
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): ProblemDescriptor =
+    manager.createProblemDescriptor(
+      guard,
+      problemMessage,
+      isOnTheFly,
+      Array[LocalQuickFix](new IfGuardQuickFix(genExpr, guard)),
+      ProblemHighlightType.WEAK_WARNING
+    )
+
+  @Nls(capitalization = Nls.Capitalization.Sentence)
+  val problemMessage =
+    "Possibly mistaken use of the if guard statement for the ZIO effect. Perhaps you wanted to use ZIO.when?"
+
+  val fixMessage = "Replace with ZIO.when"
+}

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -297,6 +297,10 @@ package object inspections {
       }
   }
 
+  object guard {
+    def unapply(expr: ScGuard): Option[ScExpression] = expr.expr
+  }
+
   object `_ => x` {
 
     def unapply(expr: ScExpression): Option[ScExpression] = expr match {

--- a/src/test/scala/intellij/testfixtures/OperationsOnCollectionInspectionTest.scala
+++ b/src/test/scala/intellij/testfixtures/OperationsOnCollectionInspectionTest.scala
@@ -16,6 +16,6 @@ abstract class OperationsOnCollectionInspectionTest extends ScalaQuickFixTestBas
 
   protected def doTest(selected: String, text: String, result: String): Unit = {
     checkTextHasError(selected)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/IfGuardInsteadOfWhenInspectionTest.scala
+++ b/src/test/scala/zio/inspections/IfGuardInsteadOfWhenInspectionTest.scala
@@ -1,0 +1,42 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.mistakes.IfGuardInsteadOfWhenInspection
+
+class IfGuardInsteadOfWhenInspectionTest extends ZScalaInspectionTest[IfGuardInsteadOfWhenInspection] {
+  override protected val description = IfGuardInsteadOfWhenInspection.problemMessage
+  private val hint                   = IfGuardInsteadOfWhenInspection.fixMessage
+
+  def test_if_guards_on_discarded_zio_effect(): Unit = {
+    z(s"""for {
+         |  x <- ZIO.succeed(1) if 1 == 2
+         |  _ <- ZIO.succeed(2) ${START}if 1 == 2$END // regular guard
+         |  _ <- ZIO.succeed(3) /* guard after block comment */ ${START}if 1 == 2$END
+         |  _ <- ZIO.succeed(4)
+         |  _ <- ZIO.succeed(5) // guard on the new line after line comment
+         |  ${START}if 2 == 2$END
+         |  y <- ZIO.succeed(6)
+         |} yield ()""".stripMargin).assertHighlighted()
+
+    val text = z(s"""for {
+                    |  x <- ZIO.succeed(1) if 1 == 2
+                    |  _ <- ZIO.succeed(2) if 1 == 2 // regular guard
+                    |  _ <- ZIO.succeed(3) /* guard after block comment */ if 1 == 2
+                    |  _ <- ZIO.succeed(4)
+                    |  _ <- ZIO.succeed(5) // guard on the new line after line comment
+                    |  if 2 == 2
+                    |  y <- ZIO.succeed(6)
+                    |} yield ()""".stripMargin)
+
+    val result = z(s"""for {
+                      |  x <- ZIO.succeed(1) if 1 == 2
+                      |  _ <- ZIO.succeed(2).when(1 == 2) // regular guard
+                      |  _ <- ZIO.succeed(3).when(1 == 2) /* guard after block comment */
+                      |  _ <- ZIO.succeed(4)
+                      |  _ <- ZIO.succeed(5).when(2 == 2) // guard on the new line after line comment
+                      |  y <- ZIO.succeed(6)
+                      |} yield ()""".stripMargin)
+
+    testQuickFixes(text, result, hint)
+  }
+}

--- a/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
@@ -14,7 +14,7 @@ class SimplifyMapTest extends MapInspectionTest(".as") {
     z(s"ZIO.succeed(42).${START}map(_ => x)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).map(_ => x)")
     val result = z("ZIO.succeed(42).as(x)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -25,6 +25,6 @@ class SimplifyMapErrorTest extends MapInspectionTest(".orElseFail") {
     z(s"ZIO.succeed(42).${START}mapError(_ => x)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).mapError(_ => x)")
     val result = z("ZIO.succeed(42).orElseFail(x)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
@@ -12,55 +12,55 @@ class SimplifyBimapInspectionTest extends ZSimplifyInspectionTest[SimplifyBimapI
     z(s"ZIO.succeed(42).${START}map(a).mapError(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).map(a).mapError(b)")
     val result = z("ZIO.succeed(42).bimap(b, a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_map_orElseFail(): Unit = {
     z(s"ZIO.succeed(42).${START}map(a).orElseFail(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).map(a).orElseFail(b)")
     val result = z("ZIO.succeed(42).bimap(_ => b, a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_as_mapError(): Unit = {
     z(s"ZIO.succeed(42).${START}as(a).mapError(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).as(a).mapError(b)")
     val result = z("ZIO.succeed(42).bimap(b, _ => a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_as_orElseFail(): Unit = {
     z(s"ZIO.succeed(42).${START}as(a).orElseFail(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).as(a).orElseFail(b)")
     val result = z("ZIO.succeed(42).bimap(_ => b, _ => a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_mapError_map(): Unit = {
     z(s"ZIO.succeed(42).${START}mapError(a).map(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).mapError(a).map(b)")
     val result = z("ZIO.succeed(42).bimap(a, b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_mapError_as(): Unit = {
     z(s"ZIO.succeed(42).${START}mapError(a).as(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).mapError(a).as(b)")
     val result = z("ZIO.succeed(42).bimap(a, _ => b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_orElseFail_map(): Unit = {
     z(s"ZIO.succeed(42).${START}orElseFail(a).map(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).orElseFail(a).map(b)")
     val result = z("ZIO.succeed(42).bimap(_ => a, b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_orElseFail_as(): Unit = {
     z(s"ZIO.succeed(42).${START}orElseFail(a).as(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).orElseFail(a).as(b)")
     val result = z("ZIO.succeed(42).bimap(_ => a, _ => b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
@@ -24,7 +24,7 @@ abstract class CollectAllInspectionTest(methodToReplace: String, methodToReplace
       s"""val myIterable: Iterable[String] = ???
          |ZIO.$methodToReplaceWith$nParamList(myIterable)(f)""".stripMargin
     )
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 

--- a/src/test/scala/zio/inspections/SimplifyForeachInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyForeachInspectionTest.scala
@@ -39,7 +39,7 @@ abstract class SimplifyForeachInspectionTest(
          |  _ <- $zioMethodToReplaceWith
          |} yield ???""".stripMargin
     }
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def testNestedForCompHighlighting(): Unit =
@@ -75,7 +75,7 @@ abstract class SimplifyForeachInspectionTest(
          |  _ <- b
          |} yield ???""".stripMargin
     }
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def testChainHighlighting(): Unit =
@@ -93,7 +93,7 @@ abstract class SimplifyForeachInspectionTest(
       s"""val myIterable: Iterable[String] = ???
          |$zioMethodToReplaceWith *> b""".stripMargin
     }
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def testNestedChainHighlighting(): Unit =
@@ -111,7 +111,7 @@ abstract class SimplifyForeachInspectionTest(
       s"""val myIterable: Iterable[String] = ???
          |b <* b *> b *> $zioMethodToReplaceWith *> b""".stripMargin
     }
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
 }

--- a/src/test/scala/zio/inspections/SimplifyIgnoreInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyIgnoreInspectionTest.scala
@@ -12,20 +12,20 @@ class SimplifyIgnoreInspectionTest extends ZSimplifyInspectionTest[SimplifyIgnor
     z(s"ZIO.succeed(42).${START}catchAll(_ => ZIO.unit)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).catchAll(_ => ZIO.unit)")
     val result = z("ZIO.succeed(42).ignore")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_foldCause_unit(): Unit = {
     z(s"ZIO.succeed(42).${START}foldCause(_ => (), _ => ())$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).foldCause(_ => (), _ => ())")
     val result = z("ZIO.succeed(42).ignore")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_foldCauseM_ZIOUnit(): Unit = {
     z(s"ZIO.succeed(42).${START}foldCauseM(_ => ZIO.unit, _ => ZIO.unit)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).foldCauseM(_ => ZIO.unit, _ => ZIO.unit)")
     val result = z("ZIO.succeed(42).ignore")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyServiceInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyServiceInspectionTest.scala
@@ -33,7 +33,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(assignment(reference)))
     val result = z(base(assignment("ZIO.service")))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_access_get_with_alias(): Unit = {
@@ -45,7 +45,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(assignment(reference)))
     val result = z(base(assignment("ZIO.service")))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_access_get_lambda(): Unit = {
@@ -57,7 +57,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(assignment(reference)))
     val result = z(base(assignment("ZIO.service")))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_not_highlighted(): Unit = {
@@ -76,7 +76,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(reference))
     val result = z(base("ZIO.service[UserRepo.Service]"))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_generic_access_get_lambda(): Unit = {
@@ -87,7 +87,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(reference))
     val result = z(base("ZIO.service[UserRepo.Service]"))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_generic_not_highlighted(): Unit = {
@@ -105,7 +105,7 @@ class SimplifyServiceInspectionTest extends ZSimplifyInspectionTest[SimplifyServ
 
     val text   = z(base(reference))
     val result = z(base("ZIO.service[UserRepo.Service]"))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
 }

--- a/src/test/scala/zio/inspections/SimplifySleepInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySleepInspectionTest.scala
@@ -12,13 +12,13 @@ class SimplifySleepInspectionTest extends ZSimplifyInspectionTest[SimplifySleepI
     z(s"""${START}ZIO.sleep(1.seconds) *> putStrLn("")$END""").assertHighlighted()
     val text   = z(s"""ZIO.sleep(1.seconds) *> putStrLn("")""")
     val result = z(s"""putStrLn("").delay(1.seconds)""")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap(): Unit = {
     z(s"""${START}ZIO.sleep(1.seconds).flatMap(_ => putStrLn(""))$END""").assertHighlighted()
     val text   = z(s"""ZIO.sleep(1.seconds) *> putStrLn("")""")
     val result = z(s"""putStrLn("").delay(1.seconds)""")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
@@ -15,42 +15,42 @@ class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO
     z(s"${START}ZIO.succeed(Left(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_succeed_util_Left(): Unit = {
     z(s"${START}ZIO.succeed(util.Left(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(util.Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_Left(): Unit = {
     z(s"${START}UIO(Left(a))$END").assertHighlighted()
     val text   = z("UIO(Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_util_Left(): Unit = {
     z(s"${START}UIO(util.Left(a))$END").assertHighlighted()
     val text   = z("UIO(util.Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_Left(): Unit = {
     z(s"${START}UIO.apply(Left(a))$END").assertHighlighted()
     val text   = z("UIO.apply(Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_util_Left(): Unit = {
     z(s"${START}UIO.apply(util.Left(a))$END").assertHighlighted()
     val text   = z("UIO.apply(util.Left(a))")
     val result = z("ZIO.left(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -61,41 +61,41 @@ class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZI
     z(s"${START}ZIO.succeed(Right(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_succeed_util_Right(): Unit = {
     z(s"${START}ZIO.succeed(util.Right(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(util.Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_Right(): Unit = {
     z(s"${START}UIO(Right(a))$END").assertHighlighted()
     val text   = z("UIO(Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_util_Right(): Unit = {
     z(s"${START}UIO(util.Right(a))$END").assertHighlighted()
     val text   = z("UIO(util.Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_Right(): Unit = {
     z(s"${START}UIO.apply(Right(a))$END").assertHighlighted()
     val text   = z("UIO.apply(Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_util_Right(): Unit = {
     z(s"${START}UIO.apply(util.Right(a))$END").assertHighlighted()
     val text   = z("UIO.apply(util.Right(a))")
     val result = z("ZIO.right(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
@@ -15,21 +15,21 @@ class SucceedNoneInspectionTest extends SimplifyOptionInspectionTest("ZIO.none")
     z(s"${START}ZIO.succeed(None)$END").assertHighlighted()
     val text   = z("ZIO.succeed(None)")
     val result = z("ZIO.none")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_None(): Unit = {
     z(s"${START}UIO(None)$END").assertHighlighted()
     val text   = z("UIO(None)")
     val result = z("ZIO.none")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_None(): Unit = {
     z(s"${START}UIO.apply(None)$END").assertHighlighted()
     val text   = z("UIO.apply(None)")
     val result = z("ZIO.none")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -40,20 +40,20 @@ class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some")
     z(s"${START}ZIO.succeed(Some(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(Some(a))")
     val result = z("ZIO.some(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_Some(): Unit = {
     z(s"${START}UIO(Some(a))$END").assertHighlighted()
     val text   = z("UIO(Some(a))")
     val result = z("ZIO.some(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_UIO_apply_None(): Unit = {
     z(s"${START}UIO.apply(Some(a))$END").assertHighlighted()
     val text   = z("UIO.apply(Some(a))")
     val result = z("ZIO.some(a)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
@@ -13,14 +13,14 @@ class SimplifyTapBothInspectionTest extends BaseSimplifyTapInspectionTest(".tapB
     z(s"ZIO.unit.${START}tap(_ => ZIO.unit).tapError(t => logError(t))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.tap(_ => ZIO.unit).tapError(t => logError(t))")
     val result = z(s"ZIO.unit.tapBoth(t => logError(t), _ => ZIO.unit)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_tapError_tap(): Unit = {
     z(s"ZIO.unit.${START}tapError(t => logError(t)).tap(_ => ZIO.unit)$END").assertHighlighted()
     val text   = z(s"ZIO.unit.tapError(t => logError(t)).tap(_ => ZIO.unit)")
     val result = z(s"ZIO.unit.tapBoth(t => logError(t), _ => ZIO.unit)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -30,42 +30,42 @@ class SimplifyTapErrorInspectionTest extends BaseSimplifyTapInspectionTest(".tap
     z(s"ZIO.unit.${START}catchAll(ex => logError(ex) *> ZIO.fail(ex))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.catchAll(ex => logError(ex) *> ZIO.fail(ex))")
     val result = z(s"ZIO.unit.tapError(logError)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMapError_reduce_func_no_params(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => f(a).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => f(a).as(a))")
     val result = z(s"ZIO.unit.tapError(f)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMapError_func_with_params(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => f(a, 42).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => f(a, 42).as(a))")
     val result = z(s"ZIO.unit.tapError(a => f(a, 42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMapError_method_invocation_on_ref(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => logger.log(a).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => logger.log(a).as(a))")
     val result = z(s"ZIO.unit.tapError(a => logger.log(a))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMapError_to_value_underscore(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => b.as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => b.as(a))")
     val result = z(s"ZIO.unit.tapError(_ => b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMapError_to_qualified_value_underscore(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => ZIO.unit.as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => ZIO.unit.as(a))")
     val result = z(s"ZIO.unit.tapError(_ => ZIO.unit)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -75,35 +75,35 @@ class SimplifyTapInspectionTest extends BaseSimplifyTapInspectionTest(".tap") {
     z(s"ZIO.unit.${START}flatMap(a => f(a).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMap(a => f(a).as(a))")
     val result = z(s"ZIO.unit.tap(f)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_func_with_params(): Unit = {
     z(s"ZIO.unit.${START}flatMap(a => f(a, 42).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMap(a => f(a, 42).as(a))")
     val result = z(s"ZIO.unit.tap(a => f(a, 42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_method_invocation_on_ref(): Unit = {
     z(s"ZIO.unit.${START}flatMap(a => logger.log(a).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMap(a => logger.log(a).as(a))")
     val result = z(s"ZIO.unit.tap(a => logger.log(a))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_to_value_underscore(): Unit = {
     z(s"ZIO.unit.${START}flatMap(a => b.as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMap(a => b.as(a))")
     val result = z(s"ZIO.unit.tap(_ => b)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_to_qualified_value_underscore(): Unit = {
     z(s"ZIO.unit.${START}flatMap(a => ZIO.unit.as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMap(a => ZIO.unit.as(a))")
     val result = z(s"ZIO.unit.tap(_ => ZIO.unit)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_forkManaged(): Unit = {
@@ -131,6 +131,6 @@ class SimplifyTapInspectionTest extends BaseSimplifyTapInspectionTest(".tap") {
                       |
                       |build.tap(_.serve().forkManaged)
                       |""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyToLayerInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyToLayerInspectionTest.scala
@@ -20,7 +20,7 @@ sealed abstract class BaseToLayerInspectionTest(methodToReplace: String, methodT
   def testReplacement(): Unit = {
     val text   = z(base(zLayerExpr))
     val result = z(base(s"serviceEffect.$methodToReplaceWith"))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 

--- a/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
@@ -12,28 +12,28 @@ class SimplifyUnitInspectionTest extends ZSimplifyInspectionTest[SimplifyUnitIns
     z(s"ZIO.succeed(42).$START*>(ZIO.unit)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).*>(ZIO.unit)")
     val result = z("ZIO.succeed(42).unit")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_zipRight_infix(): Unit = {
     z(s"ZIO.succeed(42) $START*> ZIO.unit$END").assertHighlighted()
     val text   = z("ZIO.succeed(42) *> ZIO.unit")
     val result = z("ZIO.succeed(42).unit")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_as_unit(): Unit = {
     z(s"ZIO.succeed(42).${START}as(())$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).as(())")
     val result = z("ZIO.succeed(42).unit")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_map_to_unit(): Unit = {
     z(s"ZIO.succeed(42).${START}map(_ => ())$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).map(_ => ())")
     val result = z("ZIO.succeed(42).unit")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_does_not_highlight_unit_member(): Unit =

--- a/src/test/scala/zio/inspections/SimplifyWhenInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyWhenInspectionTest.scala
@@ -18,7 +18,7 @@ class SimplifyWhenInspectionTest extends ZSimplifyInspectionTest[SimplifyWhenIns
     val result = z(s"""|val a = true
                        |val b = ZIO.succeed(42)
                        |b.when(a)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_when_direct_reference(): Unit = {
@@ -28,7 +28,7 @@ class SimplifyWhenInspectionTest extends ZSimplifyInspectionTest[SimplifyWhenIns
                      |if (a) ZIO.succeed(42) else ZIO.unit""".stripMargin)
     val result = z(s"""|val a = true
                        |ZIO.succeed(42).when(a)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_when_direct_reference_apply(): Unit = {
@@ -38,7 +38,7 @@ class SimplifyWhenInspectionTest extends ZSimplifyInspectionTest[SimplifyWhenIns
                      |if (a) ZIO(42) else ZIO.unit""".stripMargin)
     val result = z(s"""|val a = true
                        |ZIO(42).when(a)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_when_complex_reference(): Unit = {
@@ -52,6 +52,6 @@ class SimplifyWhenInspectionTest extends ZSimplifyInspectionTest[SimplifyWhenIns
     z(base(s"${START}if (a) $reference else ZIO.unit$END")).assertHighlighted()
     val text   = z(base(s"if (a) $reference else ZIO.unit"))
     val result = z(base(s"$reference.when(a)"))
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
@@ -13,7 +13,7 @@ class SimplifyFlatmapWithZipRightTest extends FlatmapInspectionTest(".zipRight")
     z(s"""ZIO.succeed("Remedios Varo").${START}flatMap(_ => x)$END""").assertHighlighted()
     val text   = z("""ZIO.succeed("Remedios Varo").flatMap(_ => x)""")
     val result = z("""ZIO.succeed("Remedios Varo").zipRight(x)""")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_not_discarding_should_not_highlight(): Unit =
@@ -27,14 +27,14 @@ class SimplifyFlatmapWithZipRightOperatorTest extends FlatmapInspectionTest("*>"
     z(s"""ZIO.succeed("Xul Solar").${START}flatMap(_ => x)$END""").assertHighlighted()
     val text   = z("""ZIO.succeed("Xul Solar").flatMap(_ => ZIO succeed x)""")
     val result = z("""ZIO.succeed("Xul Solar") *> (ZIO succeed x)""")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_to_*>(): Unit = {
     z(s"""ZIO.succeed("Frida Kahlo").${START}flatMap(_ => x)$END""").assertHighlighted()
     val text   = z("""ZIO.succeed("Frida Kahlo").flatMap(_ => ZIO.succeed(x))""")
     val result = z("""ZIO.succeed("Frida Kahlo") *> ZIO.succeed(x)""")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_flatMap_not_discarding_should_not_highlight(): Unit =

--- a/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
+++ b/src/test/scala/zio/inspections/WrapInsteadOfLiftInspectionTest.scala
@@ -19,7 +19,7 @@ class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Opti
                     |ZIO(o)""".stripMargin)
     val result = z(s"""val o: Option[Int] = Option(42)
                       |ZIO.fromOption(o)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_option_reference_apply(): Unit = {
@@ -29,35 +29,35 @@ class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Opti
                     |ZIO.apply(o)""".stripMargin)
     val result = z(s"""val o: Option[Int] = Option(42)
                       |ZIO.fromOption(o)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_option_direct_some(): Unit = {
     z(s"${START}ZIO(Some(42))$END").assertHighlighted()
     val text   = z(s"ZIO(Some(42))")
     val result = z(s"ZIO.fromOption(Some(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_option_direct_none(): Unit = {
     z(s"${START}ZIO(None)$END").assertHighlighted()
     val text   = z(s"ZIO(None)")
     val result = z(s"ZIO.fromOption(None)")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_option_effect(): Unit = {
     z(s"${START}ZIO.effect(Option(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effect(Option(42))")
     val result = z(s"ZIO.fromOption(Option(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_option_effectTotal(): Unit = {
     z(s"${START}ZIO.effectTotal(Option(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effectTotal(Option(42))")
     val result = z(s"ZIO.fromOption(Option(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_non_option_getOrElse(): Unit =
@@ -71,7 +71,7 @@ class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Opti
                     |ZIO.effect(o.map(_ + " foo"))""".stripMargin)
     val result = z(s"""val o: Option[String] = ???
                       |ZIO.fromOption(o.map(_ + " foo"))""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_nested(): Unit = {
@@ -80,7 +80,7 @@ class OptionWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Opti
 
     val text   = z("ZIO.effect(util.Right(util.Try(Option(42))).getOrElse(util.Try(None)).getOrElse(None))")
     val result = z("ZIO.fromOption(util.Right(util.Try(Option(42))).getOrElse(util.Try(None)).getOrElse(None))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -95,7 +95,7 @@ class TryWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Try") {
                     |ZIO(t)""".stripMargin)
     val result = z(s"""val t: Try[Int] = Try(42)
                       |ZIO.fromTry(t)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_try_reference_apply(): Unit = {
@@ -105,35 +105,35 @@ class TryWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Try") {
                     |ZIO.apply(t)""".stripMargin)
     val result = z(s"""val t: Try[Int] = Try(42)
                       |ZIO.fromTry(t)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_try_direct_success(): Unit = {
     z(s"${START}ZIO(Success(42))$END").assertHighlighted()
     val text   = z(s"ZIO(Success(42))")
     val result = z(s"ZIO.fromTry(Success(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_try_direct_failure(): Unit = {
     z(s"${START}ZIO(Failure(new Exception()))$END").assertHighlighted()
     val text   = z(s"ZIO(Failure(new Exception()))")
     val result = z(s"ZIO.fromTry(Failure(new Exception()))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_try_effect(): Unit = {
     z(s"${START}ZIO.effect(Try(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effect(Try(42))")
     val result = z(s"ZIO.fromTry(Try(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_try_effectTotal(): Unit = {
     z(s"${START}ZIO.effectTotal(Try(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effectTotal(Try(42))")
     val result = z(s"ZIO.fromTry(Try(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_nested(): Unit = {
@@ -142,7 +142,7 @@ class TryWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Try") {
 
     val text   = z("ZIO.effect(util.Right(util.Try(Option(42))).getOrElse(util.Try(None)))")
     val result = z("ZIO.fromTry(util.Right(util.Try(Option(42))).getOrElse(util.Try(None)))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -157,7 +157,7 @@ class EitherWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Eith
                     |ZIO(either)""".stripMargin)
     val result = z(s"""val either: Either[String, Int] = Right(42)
                       |ZIO.fromEither(either)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_either_reference_apply(): Unit = {
@@ -167,35 +167,35 @@ class EitherWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Eith
                     |ZIO.apply(either)""".stripMargin)
     val result = z(s"""val either: Either[String, Int] = Right(42)
                       |ZIO.fromEither(either)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_either_direct_right(): Unit = {
     z(s"${START}ZIO(Right(42))$END").assertHighlighted()
     val text   = z(s"ZIO(Right(42))")
     val result = z(s"ZIO.fromEither(Right(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_either_direct_left(): Unit = {
     z(s"${START}ZIO(Left(42))$END").assertHighlighted()
     val text   = z(s"ZIO(Left(42))")
     val result = z(s"ZIO.fromEither(Left(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_either_effect(): Unit = {
     z(s"${START}ZIO.effect(Right(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effect(Right(42))")
     val result = z(s"ZIO.fromEither(Right(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_either_effectTotal(): Unit = {
     z(s"${START}ZIO.effectTotal(Right(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effectTotal(Right(42))")
     val result = z(s"ZIO.fromEither(Right(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_nested(): Unit = {
@@ -204,7 +204,7 @@ class EitherWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Eith
 
     val text   = z("ZIO.effect(util.Right(util.Try(Option(42))))")
     val result = z("ZIO.fromEither(util.Right(util.Try(Option(42))))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }
 
@@ -219,7 +219,7 @@ class FutureWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Futu
                     |ZIO(future)""".stripMargin)
     val result = z(s"""val future = Future(42)
                       |ZIO.fromFuture(implicit ec => future)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_future_reference_apply(): Unit = {
@@ -229,34 +229,34 @@ class FutureWrapInspectionTest extends BaseWrapInsteadOfLiftInspectionTest("Futu
                     |ZIO.apply(future)""".stripMargin)
     val result = z(s"""val future = Future(42)
                       |ZIO.fromFuture(implicit ec => future)""".stripMargin)
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_future_direct_method(): Unit = {
     z(s"${START}ZIO(Future(42))$END").assertHighlighted()
     val text   = z(s"ZIO(Future(42))")
     val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_future_effect(): Unit = {
     z(s"${START}ZIO.effect(Future(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effect(Future(42))")
     val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_future_effectTotal(): Unit = {
     z(s"${START}ZIO.effectTotal(Future(42))$END").assertHighlighted()
     val text   = z(s"ZIO.effectTotal(Future(42))")
     val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 
   def test_zio_alias_task(): Unit = {
     z(s"${START}Task.effectTotal(Future(42))$END").assertHighlighted()
     val text   = z(s"Task.effectTotal(Future(42))")
     val result = z(s"ZIO.fromFuture(implicit ec => Future(42))")
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/YieldingZIOEffectInspectionTest.scala
+++ b/src/test/scala/zio/inspections/YieldingZIOEffectInspectionTest.scala
@@ -13,9 +13,9 @@ class YieldingZIOEffectInspectionTest extends ZScalaInspectionTest[YieldingZIOEf
                                              |""".stripMargin).assertHighlighted()
 
   def test_yielding_an_curried_2_effect(): Unit = z(s"""for {
-                                             |  _ <- ZIO.succeed(1)
-                                             |} yield ${START}ZIO.foreach(List(2))(UIO(_))$END
-                                             |""".stripMargin).assertHighlighted()
+                                                       |  _ <- ZIO.succeed(1)
+                                                       |} yield ${START}ZIO.foreach(List(2))(UIO(_))$END
+                                                       |""".stripMargin).assertHighlighted()
 
   def test_yielding_an_curried_3_effect(): Unit = z(s"""for {
                                                        |  _ <- ZIO.succeed(1)


### PR DESCRIPTION
Suggest changing
```
for {
  _ <- zioEffect if condition
} yield ()
```
to
```
for {
  _ <- zioEffect.when(condition)
} yield ()
```

since the guard here is `ZIO.withFilter` which fails with `NoSuchElementException` when `condition` is `false`.

Probably would be great to detect
```
for {
  x <- zioEffect if condition
} yield x
```
as well without suggesting to change to `ZIO.when`.