### PR TITLE
Detect test methods/suites by their return types, rather than by name

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
@@ -1,9 +1,12 @@
 package zio.intellij.testsupport
 
 import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.extensions.ResolvesTo
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScReferenceExpression
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.types.ScalaType
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
-import zio.intellij.testsupport.ZTestFramework.testMethods
+import zio.intellij.testsupport.ZTestFramework.testMethodTypes
 
 final class ZTestFramework extends AbstractTestFramework {
   override def getMarkerClassFQName: String = ZSuitePaths.head
@@ -15,13 +18,29 @@ final class ZTestFramework extends AbstractTestFramework {
 
   override def isTestMethod(element: PsiElement, checkAbstract: Boolean): Boolean =
     element match {
-      case sc: ScReferenceExpression => testMethods.contains(sc.refName)
+      case sc: ScReferenceExpression => resolvesToTestMethod(sc)
       case _                         => false
     }
 
   override def baseSuitePaths: Seq[String] = ZSuitePaths
+
+  private def resolvesToTestMethod(sc: ScReferenceExpression): Boolean =
+    sc match {
+      case ResolvesTo(f: ScFunctionDefinition) =>
+        f.returnType match {
+          case Right(returnType) =>
+            val ret = ScalaType.expandAliases(returnType).getOrElse(returnType)
+            testMethodTypes.get(sc.refName).contains(ret.canonicalText)
+          case _ => false
+        }
+      case _ => false
+    }
 }
 
 object ZTestFramework {
-  private[ZTestFramework] val testMethods = Set("test", "testM", "suite")
+  private[ZTestFramework] val testMethodTypes = Map(
+    "suite" -> "_root_.zio.test.Spec[R, E, T]",
+    "testM" -> "_root_.zio.test.Spec[R, _root_.zio.test.TestFailure[E], _root_.zio.test.TestSuccess]",
+    "test"  -> "_root_.zio.test.Spec[Any, _root_.zio.test.TestFailure[Nothing], _root_.zio.test.TestSuccess]"
+  )
 }


### PR DESCRIPTION
Fixes #128

A long outstanding issue with incorrect icon detection (e.g. if the method/variable had a `.test` prefix, i.e. `test.testM`, it would show the icon twice).
This fixes the detection by resolving to the actual types.