### PR TITLE
Fix inspections and simplifications in case of code blocks

### DIFF
--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyBimapInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyBimapInspection.scala
@@ -5,6 +5,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods._
+import zio.intellij.utils.StringUtils._
 
 class SimplifyBimapInspection extends ZInspection(BimapSimplificationType)
 
@@ -14,7 +15,7 @@ object BimapSimplificationType extends SimplificationType {
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(qual: ScExpression, a: ScExpression, b: ScExpression) =
       replace(expr)
-        .withText(invocationText(qual, s"bimap(${b.getText}, ${a.getText})"))
+        .withText(invocationText(qual, s"bimap(${b.getBracedText}, ${a.getBracedText})"))
         .highlightFrom(qual)
 
     def toFunctionExpr(e: ScExpression): ScExpression =

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
@@ -1,9 +1,10 @@
 package zio.intellij.inspections.simplifications
 
 import org.jetbrains.plugins.scala.codeInspection.collections._
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScMethodCall, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
 import zio.intellij.inspections.collectionMethods.`.map`
+import zio.intellij.utils.StringUtils._
 
 class SimplifyCollectAllInspection
     extends ZInspection(
@@ -18,7 +19,7 @@ sealed abstract class BaseCollectAllSimplificationType(methodName: String, metho
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(iterable: ScExpression, func: ScExpression) =
-      replace(expr).withText(s"ZIO.$methodName(${iterable.getText})(${func.getText})").highlightFrom(expr)
+      replace(expr).withText(s"ZIO.$methodName${iterable.getWrappedText}${func.getWrappedText}").highlightAll
 
     expr match {
       case methodExtractor(xs `.map` f) => Some(replacement(xs, f))
@@ -39,8 +40,8 @@ object CollectAllParNToForeachParNSimplificationType extends SimplificationType 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(n: ScExpression, iterable: ScExpression, func: ScExpression) =
       replace(expr)
-        .withText(s"ZIO.foreachParN(${n.getText})(${iterable.getText})(${func.getText})")
-        .highlightFrom(expr)
+        .withText(s"ZIO.foreachParN${n.getWrappedText}${iterable.getWrappedText}${func.getWrappedText}")
+        .highlightAll
 
     expr match {
       case `ZIO.collectAllParN`(n, iterable `.map` func) => Some(replacement(n, iterable, func))

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyFlatmapInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyFlatmapInspection.scala
@@ -4,6 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScInfixExpr}
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods._
+import zio.intellij.utils.StringUtils._
 
 class SimplifyFlatmapInspection extends ZInspection(ZipRightSimplificationType, ZipRightOperatorSimplificationType)
 
@@ -13,8 +14,9 @@ object ZipRightSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] =
     expr match {
-      case qual `.flatMap` `_ => x`(x) => Some(replace(expr).withText(invocationText(qual, s"zipRight(${x.getText}")))
-      case _                           => None
+      case qual `.flatMap` `_ => x`(x) =>
+        Some(replace(expr).withText(invocationText(qual, s"zipRight${x.getWrappedText}")))
+      case _ => None
     }
 
 }
@@ -27,8 +29,8 @@ object ZipRightOperatorSimplificationType extends SimplificationType {
 
     def replacement(qual: ScExpression, x: ScExpression) =
       x match {
-        case _: ScInfixExpr => replace(expr).withText(s"${qual.getText} *> (${x.getText})")
-        case _              => replace(expr).withText(s"${qual.getText} *> ${x.getText}")
+        case _: ScInfixExpr => replace(expr).withText(s"${qual.getBracedText} *> (${x.getBracedText})")
+        case _              => replace(expr).withText(s"${qual.getBracedText} *> ${x.getBracedText}")
       }
 
     expr match {

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyForeachInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyForeachInspection.scala
@@ -4,6 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScFor}
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods.`.*>`
+import zio.intellij.utils.StringUtils._
 
 class SimplifyForeachInspection
     extends ZInspection(
@@ -20,7 +21,7 @@ sealed abstract class BaseForeachSimplificationType(methodName: String) extends 
   override def hint: String = s"Replace with ZIO.$methodName"
 
   protected def replacement(expr: ScExpression, iterable: ScExpression, func: ScExpression): Simplification =
-    replace(expr).withText(s"ZIO.$methodName(${iterable.getText})(${func.getText})").highlightFrom(expr)
+    replace(expr).withText(s"ZIO.$methodName${iterable.getWrappedText}${func.getWrappedText}").highlightAll
 }
 
 sealed abstract class BaseForeachParNSimplificationType extends SimplificationType {
@@ -30,7 +31,9 @@ sealed abstract class BaseForeachParNSimplificationType extends SimplificationTy
   override def hint: String = s"Replace with ZIO.$methodName"
 
   def replacement(expr: ScExpression, n: ScExpression, iterable: ScExpression, func: ScExpression): Simplification =
-    replace(expr).withText(s"ZIO.$methodName(${n.getText})(${iterable.getText})(${func.getText})").highlightFrom(expr)
+    replace(expr)
+      .withText(s"ZIO.$methodName${n.getWrappedText}${iterable.getWrappedText}${func.getWrappedText}")
+      .highlightAll
 }
 
 sealed abstract class BaseForeachForCompSimplificationType(

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyMapInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyMapInspection.scala
@@ -4,6 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods._
+import zio.intellij.utils.StringUtils._
 
 class SimplifyMapInspection extends ZInspection(AsSimplificationType, MapErrorSimplificationType)
 
@@ -12,7 +13,7 @@ object AsSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(qual: ScExpression, arg: ScExpression) =
-      replace(expr).withText(invocationText(qual, s"as(${arg.getText}"))
+      replace(expr).withText(invocationText(qual, s"as${arg.getWrappedText}"))
     expr match {
       case qual `.map` `_ => x`(x) => Some(replacement(qual, x))
       case _                       => None
@@ -25,7 +26,7 @@ object MapErrorSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(qual: ScExpression, arg: ScExpression) =
-      replace(expr).withText(invocationText(qual, s"orElseFail(${arg.getText}"))
+      replace(expr).withText(invocationText(qual, s"orElseFail${arg.getWrappedText}"))
     expr match {
       case qual `.mapError` `_ => x`(x) => Some(replacement(qual, x))
       case _                            => None

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySleepInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySleepInspection.scala
@@ -4,6 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods._
+import zio.intellij.utils.StringUtils._
 
 class SimplifySleepInspection extends ZInspection(SleepSimplificationType)
 
@@ -12,7 +13,7 @@ object SleepSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(qual: ScExpression, duration: ScExpression) =
-      replace(expr).withText(invocationText(qual, s"delay(${duration.getText}")).highlightAll
+      replace(expr).withText(invocationText(qual, s"delay${duration.getWrappedText}")).highlightAll
     expr match {
       case `ZIO.sleep`(duration) `.*>` io                       => Some(replacement(io, duration))
       case `ZIO.sleep`(duration) `.flatMap` lambda(_, Some(io)) => Some(replacement(io, duration))

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedEitherInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedEitherInspection.scala
@@ -3,6 +3,7 @@ package zio.intellij.inspections.simplifications
 import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
+import zio.intellij.utils.StringUtils._
 
 class SimplifySucceedEitherInspection extends ZInspection(LeftSimplificationType, RightSimplificationType)
 
@@ -14,8 +15,8 @@ sealed abstract class EitherSimplificationType(extractor: TypeReference, zioMeth
 
   private def replacement(zioExpr: ScExpression, eitherArg: ScExpression): Simplification =
     replace(zioExpr)
-      .withText(s"ZIO.$zioMethodName(${eitherArg.getText}")
-      .highlightFrom(zioExpr)
+      .withText(s"ZIO.$zioMethodName${eitherArg.getWrappedText}")
+      .highlightAll
 
   private def getArg(eitherExpr: ScExpression): Option[ScExpression] =
     eitherExpr match {

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
@@ -4,6 +4,7 @@ import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
 import zio.intellij.inspections.simplifications.SimplifySucceedOptionInspection.UIOApply
+import zio.intellij.utils.StringUtils._
 
 class SimplifySucceedOptionInspection extends ZInspection(NoneSimplificationType, SomeSimplificationType)
 
@@ -13,7 +14,7 @@ object NoneSimplificationType extends SimplificationType {
   override def getSimplification(expr: ScExpression): Option[Simplification] =
     expr match {
       case `ZIO.succeed`(scalaNone()) | UIOApply(scalaNone()) =>
-        Some(replace(expr).withText("ZIO.none").highlightFrom(expr))
+        Some(replace(expr).withText("ZIO.none").highlightAll)
       case _ => None
     }
 }
@@ -22,7 +23,7 @@ object SomeSimplificationType extends SimplificationType {
   override def hint: String = "Replace with ZIO.some"
 
   private def replacement(expr: ScExpression, a: ScExpression): Simplification =
-    replace(expr).withText(s"ZIO.some(${a.getText}").highlightFrom(expr)
+    replace(expr).withText(s"ZIO.some${a.getWrappedText}").highlightAll
 
   override def getSimplification(expr: ScExpression): Option[Simplification] =
     expr match {

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyTapInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyTapInspection.scala
@@ -11,6 +11,7 @@ import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.{createE
 import zio.intellij.inspections.zioMethods._
 import zio.intellij.inspections.{ZInspection, _}
 import zio.intellij.utils.isElementUsed
+import zio.intellij.utils.StringUtils._
 
 class SimplifyTapInspection
     extends ZInspection(
@@ -111,7 +112,7 @@ object TapBothSimplificationType extends SimplificationType {
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def replacement(qual: ScExpression, tapError: ScExpression, tap: ScExpression) =
       replace(expr)
-        .withText(invocationText(qual, s"tapBoth(${tapError.getText}, ${tap.getText})"))
+        .withText(invocationText(qual, s"tapBoth(${tapError.getBracedText}, ${tap.getBracedText})"))
         .highlightFrom(qual)
 
     expr match {

--- a/src/main/scala/zio/intellij/utils/StringUtils.scala
+++ b/src/main/scala/zio/intellij/utils/StringUtils.scala
@@ -1,0 +1,29 @@
+package zio.intellij.utils
+
+import org.jetbrains.plugins.scala.extensions.{PsiElementExt, StringExt}
+import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenTypes
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+
+object StringUtils {
+
+  implicit class ScExpressionExt(val expr: ScExpression) extends AnyVal {
+
+    // injects only braces if required
+    def getBracedText: String = wrap(needParenthesis = false)
+
+    // injects braces or parenthesis depending on the expression content
+    def getWrappedText: String = wrap()
+
+    private def wrap(needParenthesis: Boolean = true, needBraces: Boolean = true): String = {
+      val exprText = expr.getText
+      // stupid hack found in scala plugin
+      val bracesRequired = exprText.contains('\n')
+
+      if (bracesRequired)
+        exprText.braced(needBraces = needBraces && !expr.startsWithToken(ScalaTokenTypes.tLBRACE))
+      else
+        exprText.parenthesize(needParenthesis = needParenthesis && !expr.startsWithToken(ScalaTokenTypes.tLPARENTHESIS))
+    }
+  }
+
+}

--- a/src/test/scala/intellij/testfixtures/ScalaHighlightsTestBase.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaHighlightsTestBase.scala
@@ -40,7 +40,7 @@ abstract class ScalaHighlightsTestBase extends ScalaLightCodeInsightFixtureTestA
   }
 
   protected def checkTextHasError(text: String, allowAdditionalHighlights: Boolean = false): Unit = {
-    val expectedRanges = selectedRanges(text)
+    val expectedRanges = selectedRanges(normalize(text))
     val actualRanges   = findRanges(text)
     checkTextHasError(expectedRanges, actualRanges, allowAdditionalHighlights)
   }

--- a/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyAsInspectionTest.scala
@@ -16,6 +16,31 @@ class SimplifyMapTest extends MapInspectionTest(".as") {
     val result = z("ZIO.succeed(42).as(x)")
     testQuickFixes(text, result, hint)
   }
+
+  def test_block_map_to_x(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}map { _ =>
+         |  x
+         |  x
+         |  x
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).map { _ =>
+        |  x
+        |  x
+        |  x
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).as {
+        |  x
+        |  x
+        |  x
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
 }
 
 class SimplifyMapErrorTest extends MapInspectionTest(".orElseFail") {
@@ -25,6 +50,31 @@ class SimplifyMapErrorTest extends MapInspectionTest(".orElseFail") {
     z(s"ZIO.succeed(42).${START}mapError(_ => x)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).mapError(_ => x)")
     val result = z("ZIO.succeed(42).orElseFail(x)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_mapError_to_x(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}mapError { _ =>
+         |  x
+         |  x
+         |  x
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).mapError { _ =>
+        |  x
+        |  x
+        |  x
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).orElseFail {
+        |  x
+        |  x
+        |  x
+        |}""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyBimapInspectionTest.scala
@@ -15,10 +15,90 @@ class SimplifyBimapInspectionTest extends ZSimplifyInspectionTest[SimplifyBimapI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_map_mapError(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}map { a =>
+         |  a
+         |  a
+         |  a
+         |}
+         |.mapError { b =>
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).map { a =>
+        |  a
+        |  a
+        |  a
+        |}.mapError { b =>
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  b =>
+        |    b
+        |    b
+        |    b
+        |  }, {
+        |  a =>
+        |    a
+        |    a
+        |    a
+        |  })""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_map_orElseFail(): Unit = {
     z(s"ZIO.succeed(42).${START}map(a).orElseFail(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).map(a).orElseFail(b)")
     val result = z("ZIO.succeed(42).bimap(_ => b, a)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_map_orElseFail(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}map { a =>
+         |  a
+         |  a
+         |  a
+         |}.orElseFail {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).map { a =>
+        |  a
+        |  a
+        |  a
+        |}.orElseFail {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  _ => {
+        |      b
+        |      b
+        |      b
+        |    }
+        |}, {
+        |  a =>
+        |    a
+        |    a
+        |    a
+        |})""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 
@@ -29,10 +109,90 @@ class SimplifyBimapInspectionTest extends ZSimplifyInspectionTest[SimplifyBimapI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_as_mapError(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}as {
+         |  a
+         |  a
+         |  a
+         |}.mapError{
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).as {
+        |  a
+        |  a
+        |  a
+        |}.mapError {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  b
+        |  b
+        |  b
+        |}, {
+        |  _ => {
+        |    a
+        |    a
+        |    a
+        |  }
+        |})""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_as_orElseFail(): Unit = {
     z(s"ZIO.succeed(42).${START}as(a).orElseFail(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).as(a).orElseFail(b)")
     val result = z("ZIO.succeed(42).bimap(_ => b, _ => a)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_as_orElseFail(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}as {
+         |  a
+         |  a
+         |  a
+         |}.orElseFail {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).as {
+        |  a
+        |  a
+        |  a
+        |}.orElseFail {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  _ => {
+        |    b
+        |    b
+        |    b
+        |  }
+        |}, {
+        |  _ => {
+        |      a
+        |      a
+        |      a
+        |    }
+        |})""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 
@@ -43,10 +203,86 @@ class SimplifyBimapInspectionTest extends ZSimplifyInspectionTest[SimplifyBimapI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_mapError_map(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}mapError {
+         |  a
+         |  a
+         |  a
+         |}.map {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).mapError {
+        |  a
+        |  a
+        |  a
+        |}.map {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  a
+        |  a
+        |  a
+        |}, {
+        |  b
+        |  b
+        |  b
+        |})""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_mapError_as(): Unit = {
     z(s"ZIO.succeed(42).${START}mapError(a).as(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).mapError(a).as(b)")
     val result = z("ZIO.succeed(42).bimap(a, _ => b)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_mapError_as(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}mapError {
+         |  a
+         |  a
+         |  a
+         |}.as {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).mapError {
+        |  a
+        |  a
+        |  a
+        |}.as {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  a
+        |  a
+        |  a
+        |}, {
+        |  _ => {
+        |      b
+        |      b
+        |      b
+        |    }
+        |})""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 
@@ -57,10 +293,91 @@ class SimplifyBimapInspectionTest extends ZSimplifyInspectionTest[SimplifyBimapI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_orElseFail_map(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}orElseFail {
+         |  a
+         |  a
+         |  a
+         |}.map {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed(42).orElseFail {
+        |  a
+        |  a
+        |  a
+        |}.map {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        | _ => {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}, {
+        |  b
+        |  b
+        |  b
+        |})""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_orElseFail_as(): Unit = {
     z(s"ZIO.succeed(42).${START}orElseFail(a).as(b)$END").assertHighlighted()
     val text   = z("ZIO.succeed(42).orElseFail(a).as(b)")
     val result = z("ZIO.succeed(42).bimap(_ => a, _ => b)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_orElseFail_as(): Unit = {
+    z {
+      s"""ZIO.succeed(42).${START}orElseFail {
+         |  a
+         |  a
+         |  a
+         |}.as {
+         |  b
+         |  b
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+    val text = z {
+      """ZIO.succeed(42).orElseFail {
+        |  a
+        |  a
+        |  a
+        |}.as {
+        |  b
+        |  b
+        |  b
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed(42).bimap({
+        |  _ => {
+        |      a
+        |      a
+        |      a
+        |    }
+        |}, {
+        |  _ => {
+        |      b
+        |      b
+        |      b
+        |    }
+        |})""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
@@ -26,6 +26,40 @@ abstract class CollectAllInspectionTest(methodToReplace: String, methodToReplace
     )
     testQuickFixes(text, result, hint)
   }
+
+  def testBlockHighlighting(): Unit =
+    z {
+      s"""val myIterable: Iterable[String] = ???
+         |${START}URIO.$methodToReplace$nParamList(myIterable.map { it =>
+         |  b
+         |  b
+         |  b
+         |  f(it)
+         |})$END""".stripMargin
+    }.assertHighlighted()
+
+  def testBlockReplacement(): Unit = {
+    val text = z {
+      s"""val myIterable: Iterable[String] = ???
+         |URIO.$methodToReplace$nParamList(myIterable.map { it =>
+         |  b
+         |  b
+         |  b
+         |  f(it)
+         |})""".stripMargin
+    }
+    val result = z {
+      s"""val myIterable: Iterable[String] = ???
+         |ZIO.$methodToReplaceWith$nParamList(myIterable) {
+         |  it =>
+         |    b
+         |    b
+         |    b
+         |    f(it)
+         |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
 }
 
 class SimplifyCollectAllToForeachTest

--- a/src/test/scala/zio/inspections/SimplifySleepInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySleepInspectionTest.scala
@@ -15,10 +15,60 @@ class SimplifySleepInspectionTest extends ZSimplifyInspectionTest[SimplifySleepI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_zipRight(): Unit = {
+    z {
+      s"""${START}ZIO.sleep {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |} *> putStrLn("")$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      s"""ZIO.sleep {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |} *> putStrLn("")""".stripMargin
+    }
+    val result = z {
+      s"""putStrLn("").delay {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_flatMap(): Unit = {
     z(s"""${START}ZIO.sleep(1.seconds).flatMap(_ => putStrLn(""))$END""").assertHighlighted()
-    val text   = z(s"""ZIO.sleep(1.seconds) *> putStrLn("")""")
+    val text   = z(s"""ZIO.sleep(1.seconds).flatMap(_ => putStrLn(""))""")
     val result = z(s"""putStrLn("").delay(1.seconds)""")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_flatMap(): Unit = {
+    z {
+      s"""${START}ZIO.sleep {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |}.flatMap(_ => putStrLn(""))$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      s"""ZIO.sleep {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |}.flatMap(_ => putStrLn(""))""".stripMargin
+    }
+    val result = z {
+      s"""putStrLn("").delay {
+         |  1.seconds
+         |  1.seconds
+         |  1.seconds
+         |}""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
@@ -18,10 +18,68 @@ class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_succeed_Left(): Unit = {
+    z {
+      s"""${START}ZIO.succeed {
+         |  Left {
+         |    a
+         |    a
+         |    a
+         |  }
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed {
+        |  Left {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.left {
+        |  a
+        |  a
+        |  a
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_succeed_util_Left(): Unit = {
     z(s"${START}ZIO.succeed(util.Left(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(util.Left(a))")
     val result = z("ZIO.left(a)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_succeed_util_Left(): Unit = {
+    z {
+      s"""${START}ZIO.succeed {
+         |  util.Left {
+         |    a
+         |    a
+         |    a
+         |  }
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed {
+        | util.Left {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.left {
+        |  a
+        |  a
+        |  a
+        |}""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 
@@ -64,10 +122,68 @@ class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZI
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_succeed_Right(): Unit = {
+    z {
+      s"""${START}ZIO.succeed {
+         |  Right {
+         |    a
+         |    a
+         |    a
+         |  }
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed {
+        |  Right {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.right {
+        |  a
+        |  a
+        |  a
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_succeed_util_Right(): Unit = {
     z(s"${START}ZIO.succeed(util.Right(a))$END").assertHighlighted()
     val text   = z("ZIO.succeed(util.Right(a))")
     val result = z("ZIO.right(a)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_succeed_util_Right(): Unit = {
+    z {
+      s"""${START}ZIO.succeed {
+         |  util.Right {
+         |    a
+         |    a
+         |    a
+         |  }
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed {
+        | util.Right {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.right {
+        |  a
+        |  a
+        |  a
+        |}""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 

--- a/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
@@ -43,6 +43,35 @@ class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some")
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_succeed_Some(): Unit = {
+    z {
+      s"""${START}ZIO.succeed {
+         |  Some {
+         |    a
+         |    a
+         |    a
+         |  }
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed {
+        |  Some {
+        |    a
+        |    a
+        |    a
+        |  }
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.some {
+        |  a
+        |  a
+        |  a
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_UIO_Some(): Unit = {
     z(s"${START}UIO(Some(a))$END").assertHighlighted()
     val text   = z("UIO(Some(a))")

--- a/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
@@ -16,10 +16,88 @@ class SimplifyTapBothInspectionTest extends BaseSimplifyTapInspectionTest(".tapB
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_tap_tapError(): Unit = {
+    z {
+      s"""ZIO.unit.${START}tap { _ =>
+         |  ZIO.unit
+         |  ZIO.unit
+         |  ZIO.unit
+         |}.tapError { t =>
+         |  logError(t)
+         |  logError(t)
+         |  logError(t)
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      s"""ZIO.unit.tap { _ =>
+         |  ZIO.unit
+         |  ZIO.unit
+         |  ZIO.unit
+         |}.tapError { t =>
+         |  logError(t)
+         |  logError(t)
+         |  logError(t)
+         |}""".stripMargin
+    }
+    val result = z {
+      s"""ZIO.unit.tapBoth({
+         |  t =>
+         |    logError(t)
+         |    logError(t)
+         |    logError(t)
+         |}, {
+         |  _ =>
+         |    ZIO.unit
+         |    ZIO.unit
+         |    ZIO.unit
+         |})""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_tapError_tap(): Unit = {
     z(s"ZIO.unit.${START}tapError(t => logError(t)).tap(_ => ZIO.unit)$END").assertHighlighted()
     val text   = z(s"ZIO.unit.tapError(t => logError(t)).tap(_ => ZIO.unit)")
     val result = z(s"ZIO.unit.tapBoth(t => logError(t), _ => ZIO.unit)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_tapError_tap(): Unit = {
+    z {
+      s"""ZIO.unit.${START}tapError { t =>
+         |  logError(t)
+         |  logError(t)
+         |  logError(t)
+         |}.tap { _ =>
+         |  ZIO.unit
+         |  ZIO.unit
+         |  ZIO.unit
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      s"""ZIO.unit.tapError { t =>
+         |  logError(t)
+         |  logError(t)
+         |  logError(t)
+         |}.tap { _ =>
+         |  ZIO.unit
+         |  ZIO.unit
+         |  ZIO.unit
+         |}""".stripMargin
+    }
+    val result = z {
+      s"""ZIO.unit.tapBoth({
+         |  t =>
+         |    logError(t)
+         |    logError(t)
+         |    logError(t)
+         |}, {
+         |  _ =>
+         |    ZIO.unit
+         |    ZIO.unit
+         |    ZIO.unit
+         |})""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
@@ -16,6 +16,32 @@ class SimplifyFlatmapWithZipRightTest extends FlatmapInspectionTest(".zipRight")
     testQuickFixes(text, result, hint)
   }
 
+  def test_blockflatMap_to_zipRight(): Unit = {
+    z {
+      s"""ZIO.succeed("Remedios Varo").${START}flatMap { _ =>
+         |  x
+         |  x
+         |  x
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+    val text = z {
+      """ZIO.succeed("Remedios Varo").flatMap { _ =>
+        |  x
+        |  x
+        |  x
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed("Remedios Varo").zipRight {
+        | x
+        | x
+        | x
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_flatMap_not_discarding_should_not_highlight(): Unit =
     z(s"""ZIO.succeed("Tarsila do Amaral").${START}flatMap(x => x)$END""").assertNotHighlighted()
 
@@ -30,10 +56,60 @@ class SimplifyFlatmapWithZipRightOperatorTest extends FlatmapInspectionTest("*>"
     testQuickFixes(text, result, hint)
   }
 
+  def test_block_infix_flatMap_to_*>(): Unit = {
+    z {
+      s"""ZIO.succeed("Xul Solar").${START}flatMap { _ =>
+         |  ZIO succeed x
+         |  ZIO succeed x
+         |  ZIO succeed x
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed("Xul Solar").flatMap { _ =>
+        |  ZIO succeed x
+        |  ZIO succeed x
+        |  ZIO succeed x
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed("Xul Solar") *> {
+        |  ZIO succeed x
+        |  ZIO succeed x
+        |  ZIO succeed x
+        |}""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
   def test_flatMap_to_*>(): Unit = {
     z(s"""ZIO.succeed("Frida Kahlo").${START}flatMap(_ => x)$END""").assertHighlighted()
     val text   = z("""ZIO.succeed("Frida Kahlo").flatMap(_ => ZIO.succeed(x))""")
     val result = z("""ZIO.succeed("Frida Kahlo") *> ZIO.succeed(x)""")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_block_flatMap_to_*>(): Unit = {
+    z {
+      s"""ZIO.succeed("Frida Kahlo").${START}flatMap { _ =>
+         |  ZIO.succeed(x)
+         |  ZIO.succeed(x)
+         |  ZIO.succeed(x)
+         |}$END""".stripMargin
+    }.assertHighlighted()
+    val text = z {
+      """ZIO.succeed("Frida Kahlo").flatMap { _ =>
+        |  ZIO.succeed(x)
+        |  ZIO.succeed(x)
+        |  ZIO.succeed(x)
+        |}""".stripMargin
+    }
+    val result = z {
+      """ZIO.succeed("Frida Kahlo") *> {
+        |  ZIO.succeed(x)
+        |  ZIO.succeed(x)
+        |  ZIO.succeed(x)
+        |}""".stripMargin
+    }
     testQuickFixes(text, result, hint)
   }
 


### PR DESCRIPTION
Closes #146.
Turns out there is a lot of similar cases when simplification of code blocks led to incorrect results. I've tried to fix as many cases as I could find.
Hopefully, this PR fixes more bugs than it introduces :)