### PR TITLE
Implement searcher for ZIO method accessors

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -161,6 +161,8 @@
         <codeInsight.lineMarkerProvider implementationClass="zio.intellij.gutter.ForkedCodeLineMarkerProvider"
                                         language="Scala"/>
 
+        <referencesSearch implementation="zio.intellij.searchers.ZioAccessorUsagesSearcher"/>
+
         <!-- test runner -->
         <configurationType implementation="zio.intellij.testsupport.ZTestConfigurationType"/>
         <runConfigurationProducer implementation="zio.intellij.testsupport.ZTestRunConfigurationProducer"/>

--- a/src/main/scala/zio/intellij/inspections/mistakes/IfGuardInsteadOfWhenInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/IfGuardInsteadOfWhenInspection.scala
@@ -11,6 +11,7 @@ import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.createEl
 import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker
 import zio.intellij.inspections._
 import zio.intellij.inspections.mistakes.IfGuardInsteadOfWhenInspection.createFix
+import zio.intellij.utils.TypeCheckUtils._
 
 class IfGuardInsteadOfWhenInspection extends AbstractRegisteredInspection {
 

--- a/src/main/scala/zio/intellij/inspections/mistakes/NothingInContravariantPositionInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/NothingInContravariantPositionInspection.scala
@@ -8,7 +8,7 @@ import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScParameterizedTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
-import zio.intellij.inspections.zioLikePackages
+import zio.intellij.utils.TypeCheckUtils.zioLikePackages
 
 class NothingInContravariantPositionInspection extends AbstractRegisteredInspection {
 

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -8,7 +8,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTemplateDefinition}
-import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import zio.intellij.utils.TypeCheckUtils._
 
 package object inspections {
 
@@ -47,29 +47,8 @@ package object inspections {
     private[inspections] val `.get` = invocation("get").from(zioHasLikeClasses)
   }
 
-  val zioTypes        = Array("zio.ZIO", "zio.UIO", "zio.RIO", "zio.URIO", "zio.IO", "zio.Task")
-  val managedTypes    = Array("zio.ZManaged")
-  val extraTypes      = Array("zio.Fiber", "zio.ZQueue", "zio.ZRef", "zio.ZRefM", "zio.ZQuery")
-  val zioTest         = Array("zio.test._")
-  val zioLikePackages = zioTypes ++ managedTypes ++ extraTypes ++ zioTest
-
   def invocation(methodName: String)  = new Qualified(methodName == _)
   def unqualified(methodName: String) = new Unqualified(methodName == _)
-
-  def fromZioLike(r: ScExpression): Boolean =
-    isOfClassFrom(r, zioLikePackages)
-
-  def fromZioLike(tpe: ScType): Boolean =
-    isOfClassFrom(tpe, zioLikePackages)
-
-  def fromZio(r: ScExpression): Boolean =
-    isOfClassFrom(r, zioTypes)
-
-  def fromZio(tpe: ScType): Boolean =
-    isOfClassFrom(tpe, zioTypes)
-
-  def fromManaged(tpe: ScType): Boolean =
-    isOfClassFrom(tpe, managedTypes)
 
   object methodExtractors {
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyChainToForInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyChainToForInspection.scala
@@ -11,6 +11,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.templates.ScTemplateBod
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import zio.intellij.inspections._
 import zio.intellij.inspections.zioMethods.`.*>`
+import zio.intellij.utils.TypeCheckUtils._
 
 class SimplifyChainToForInspection extends ZInspection(ChainToForSimplificationType, ForToChainSimplificationType)
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyToLayerInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyToLayerInspection.scala
@@ -3,6 +3,7 @@ package zio.intellij.inspections.simplifications
 import org.jetbrains.plugins.scala.codeInspection.collections._
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import zio.intellij.inspections._
+import zio.intellij.utils.TypeCheckUtils._
 
 class SimplifyToLayerInspection
     extends ZInspection(ZLayerFromEffectToLayerSimplificationType, ZLayerFromEffectManyToLayerManySimplificationType)

--- a/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
+++ b/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
@@ -9,7 +9,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr.ScUnderscoreSection
 import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
-import zio.intellij.inspections._
+import zio.intellij.utils.TypeCheckUtils._
 
 abstract class ZTypeAnnotationIntention extends AbstractTypeAnnotationIntention with ZIcon {
   final override def getText: String = getFamilyName

--- a/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
+++ b/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
@@ -20,8 +20,8 @@ import org.jetbrains.plugins.scala.lang.psi.types.{AliasType, ScType, TypePresen
 import org.jetbrains.plugins.scala.lang.psi.{ScalaPsiUtil, TypeAdjuster}
 import org.jetbrains.plugins.scala.project.ProjectContext
 import org.jetbrains.plugins.scala.util.IntentionAvailabilityChecker.checkIntention
-import zio.intellij.inspections.fromZioLike
 import zio.intellij.intentions.ZTypeAnnotationIntention
+import zio.intellij.utils.TypeCheckUtils.fromZioLike
 
 // borrowed from MakeTypeMoreSpecificIntention
 

--- a/src/main/scala/zio/intellij/searchers/ZioAccessorUsagesSearcher.scala
+++ b/src/main/scala/zio/intellij/searchers/ZioAccessorUsagesSearcher.scala
@@ -1,0 +1,111 @@
+package zio.intellij.searchers
+
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.search.searches.ReferencesSearch._
+import com.intellij.psi.{PsiClass, PsiElement, PsiReference}
+import com.intellij.util.{Processor, QueryExecutor}
+import org.jetbrains.plugins.scala.extensions.{inReadAction, ContainingClass}
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
+import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
+import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScFunctionDeclaration, ScFunctionDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypedDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTrait}
+import org.jetbrains.plugins.scala.lang.psi.types.{PhysicalMethodSignature, TermSignature}
+import zio.intellij.utils.TypeCheckUtils._
+import zio.intellij.utils._
+
+class ZioAccessorUsagesSearcher extends QueryExecutor[PsiReference, ReferencesSearch.SearchParameters] {
+
+  private val zioTraitNames = Set("Service")
+
+  object ContainingFieldClass {
+    def unapply(element: ScFieldId): Option[PsiClass] =
+      element.nameContext match {
+        case ContainingClass(c) => Some(c)
+        case _                  => None
+      }
+  }
+
+  object ContainingObject {
+    def unapply(element: PsiClass): Option[ScObject] =
+      element match {
+        case ContainingClass(obj: ScObject) => Some(obj)
+        case _                              => None
+      }
+  }
+
+  def execute(queryParameters: SearchParameters, consumer: Processor[_ >: PsiReference]): Boolean = {
+    val element: PsiElement = queryParameters.getElementToSearch
+    val accessorOpt = inReadAction {
+      element match {
+        case m: ScFunctionDeclaration => findMethodAccessor(m)
+        case m: ScFunctionDefinition  => findMethodAccessor(m)
+        case f: ScReferencePattern    => findFieldAccessor(f)
+        case f: ScFieldId             => findFieldAccessor(f)
+        case _                        => None
+      }
+    }
+    accessorOpt match {
+      case Some(accessor) =>
+        val processor = new Processor[PsiReference] {
+          override def process(ref: PsiReference): Boolean = inReadAction(consumer.process(ref))
+        }
+        ReferencesSearch
+          .search(accessor, queryParameters.getEffectiveSearchScope, queryParameters.isIgnoreAccessScope)
+          .forEach(processor)
+      case _ => true
+    }
+  }
+
+  private def findMethodAccessor(method: ScFunction): Option[PsiElement] = {
+    val containingTrait = Some(method).collect {
+      case ContainingClass(tr: ScTrait) => tr
+    }
+    val service = containingTrait.filter(tr => zioTraitNames(tr.name))
+    val containingObject =
+      service.collect {
+        case ContainingObject(obj) => obj
+      }
+
+    containingObject.toSeq.flatMap(_.allMethods).find(isAccessorMethod(method, _)).map(_.namedElement)
+  }
+
+  private def findFieldAccessor(field: ScTypedDefinition): Option[PsiElement] = {
+    val containingTrait = Some(field).collect {
+      case ContainingClass(tr: ScTrait)      => tr
+      case ContainingFieldClass(tr: ScTrait) => tr
+    }
+    val service = containingTrait.filter(tr => zioTraitNames(tr.name))
+    val containingObject =
+      service.collect {
+        case ContainingObject(obj) => obj
+      }
+
+    containingObject.toSeq.flatMap(_.allVals).find(isAccessorField(field, _)).map(_.namedElement)
+  }
+
+  private def isAccessorMethod(method: ScFunction, candidate: PhysicalMethodSignature): Boolean = candidate match {
+    case Method(acc) =>
+      acc.name == method.name && fromZio(acc.returnType.getOrAny) && areParamsSame(acc.parameters, method.parameters)
+    case _ => false
+  }
+
+  private def isAccessorField(field: ScTypedDefinition, candidate: TermSignature): Boolean = candidate match {
+    case Field(f) => f.name == field.name && fromZio(f.`type`.getOrAny)
+    case _        => false
+  }
+
+  // no equals for ScParameter :(
+  private def areParamsSame(seq1: Seq[ScParameter], seq2: Seq[ScParameter]): Boolean = {
+    val isSameLength = seq1.length == seq2.length
+
+    lazy val areSameElements =
+      seq1.zip(seq2).forall {
+        case (p1, p2) =>
+          p1.name == p2.name && p1.`type` == p2.`type`
+      }
+
+    isSameLength && areSameElements
+  }
+}

--- a/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
@@ -8,7 +8,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinitio
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
 import org.jetbrains.plugins.scala.lang.psi.types.{ScParameterizedType, ScType, TermSignature}
 import zio.intellij.synthetic.macros.utils.presentation.defaultPresentationStringForScalaType
-import zio.intellij.utils.{createType, extractTypeArguments, findTypeDefByName, resolveAliases}
+import zio.intellij.utils._
 
 /**
  * @see https://github.com/zio/zio/blob/fa998a4ba8415bf9b6bb6b76db0eb42801ed4e5a/test/shared/src/main/scala-2.x/zio/test/mock/MockableMacro.scala

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessible.scala
@@ -4,7 +4,8 @@ import org.jetbrains.plugins.scala.lang.psi.api.base.ScAnnotation
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScObject, ScTypeDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.SyntheticMembersInjector
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
-import zio.intellij.inspections.{fromManaged, fromZio}
+import zio.intellij.utils.TypeCheckUtils._
+import zio.intellij.utils._
 
 class ModulePatternAccessible extends SyntheticMembersInjector {
 

--- a/src/main/scala/zio/intellij/synthetic/macros/package.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/package.scala
@@ -1,34 +1,11 @@
 package zio.intellij.synthetic
 
-import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
-import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScTypeParam
-import org.jetbrains.plugins.scala.lang.psi.api.statements.{ScFunction, ScFunctionDeclaration, ScFunctionDefinition}
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScNamedElement, ScTypeParametersOwner}
-import org.jetbrains.plugins.scala.lang.psi.types.result.Typeable
-import org.jetbrains.plugins.scala.lang.psi.types.{PhysicalMethodSignature, TermSignature}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScTypeParametersOwner
 import zio.intellij.synthetic.macros.utils.presentation._
 
 package object macros {
-
-  object Field {
-
-    def unapply(ts: TermSignature): Option[ScNamedElement with Typeable] =
-      Some(ts.namedElement).collect {
-        case fid: ScFieldId          => fid
-        case ref: ScReferencePattern => ref
-      }
-  }
-
-  object Method {
-
-    def unapply(ts: TermSignature): Option[ScFunction] =
-      ts match {
-        case PhysicalMethodSignature(method: ScFunctionDeclaration, _) => Some(method)
-        case PhysicalMethodSignature(method: ScFunctionDefinition, _)  => Some(method)
-        case _                                                         => None
-      }
-  }
 
   def typeParametersDefinition(tpo: ScTypeParametersOwner, showVariance: Boolean): String =
     tpo.typeParametersClause.fold("")(presentationStringForScalaTypeParameters(_, showVariance))

--- a/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
+++ b/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
@@ -1,0 +1,30 @@
+package zio.intellij.utils
+
+import org.jetbrains.plugins.scala.codeInspection.collections.isOfClassFrom
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
+
+object TypeCheckUtils {
+
+  val zioTypes        = Array("zio.ZIO", "zio.UIO", "zio.RIO", "zio.URIO", "zio.IO", "zio.Task")
+  val managedTypes    = Array("zio.ZManaged")
+  val extraTypes      = Array("zio.Fiber", "zio.ZQueue", "zio.ZRef", "zio.ZRefM", "zio.ZQuery")
+  val zioTest         = Array("zio.test._")
+  val zioLikePackages = zioTypes ++ managedTypes ++ extraTypes ++ zioTest
+
+  def fromZioLike(r: ScExpression): Boolean =
+    isOfClassFrom(r, zioLikePackages)
+
+  def fromZioLike(tpe: ScType): Boolean =
+    isOfClassFrom(tpe, zioLikePackages)
+
+  def fromZio(r: ScExpression): Boolean =
+    isOfClassFrom(r, zioTypes)
+
+  def fromZio(tpe: ScType): Boolean =
+    isOfClassFrom(tpe, zioTypes)
+
+  def fromManaged(tpe: ScType): Boolean =
+    isOfClassFrom(tpe, managedTypes)
+
+}

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -5,11 +5,24 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.{JavaPsiFacade, PsiElement}
 import org.jetbrains.plugins.scala.annotator.usageTracker.ScalaRefCountHolder
-import org.jetbrains.plugins.scala.lang.psi.api.statements.ScTypeAliasDefinition
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
+import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
+import org.jetbrains.plugins.scala.lang.psi.api.statements.{
+  ScFunction,
+  ScFunctionDeclaration,
+  ScFunctionDefinition,
+  ScTypeAliasDefinition
+}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScNamedElement, ScTypedDefinition}
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
-import org.jetbrains.plugins.scala.lang.psi.types.{AliasType, ScParameterizedType, ScType}
+import org.jetbrains.plugins.scala.lang.psi.types.{
+  AliasType,
+  PhysicalMethodSignature,
+  ScParameterizedType,
+  ScType,
+  TermSignature
+}
 
 package object utils {
 
@@ -81,5 +94,24 @@ package object utils {
       case parameterizedType: ScParameterizedType => Some(parameterizedType.typeArguments)
       case _                                      => None
     }
+
+  object Field {
+
+    def unapply(ts: TermSignature): Option[ScTypedDefinition] =
+      Some(ts.namedElement).collect {
+        case fid: ScFieldId          => fid
+        case ref: ScReferencePattern => ref
+      }
+  }
+
+  object Method {
+
+    def unapply(ts: TermSignature): Option[ScFunction] =
+      ts match {
+        case PhysicalMethodSignature(method: ScFunctionDeclaration, _) => Some(method)
+        case PhysicalMethodSignature(method: ScFunctionDefinition, _)  => Some(method)
+        case _                                                         => None
+      }
+  }
 
 }

--- a/src/test/scala/intellij/testfixtures/Markers.scala
+++ b/src/test/scala/intellij/testfixtures/Markers.scala
@@ -1,0 +1,196 @@
+package org.jetbrains.plugins.scala.util
+
+import com.intellij.openapi.util.TextRange
+import org.junit.Assert._
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+trait Markers {
+
+  protected val caretText = "<caret>"
+  def startMarker(i: Int) = s"/*start$i*/"
+  def endMarker(i: Int)   = s"/*end$i*/"
+  val startMarker         = "/*start*/"
+  val endMarker           = "/*end*/"
+
+  def start(i: Int = 0): String = startMarker(i)
+  def end(i: Int = 0): String   = endMarker(i)
+  def start: String             = startMarker
+  def end: String               = endMarker
+
+  /**
+   * @example
+   * line /start/ 1 content /end/
+   * line /start0/ /start1/ 2 /end1/ content/end0/
+   */
+  def extractMarkers(inputText: String): (String, Seq[TextRange]) = {
+    var input         = inputText
+    val caretPosition = inputText.indexOf(caretText)
+    def removeCaret(index: Int): Int =
+      if (caretPosition >= 0 && index > caretPosition) index - caretText.length else index
+    val markerPositions = mutable.Map[String, Int]()
+    val textRanges      = mutable.Buffer.empty[TextRange]
+
+    def detectMarker(start: String, end: String): Boolean =
+      input.contains(start) && input.contains(end) && {
+        markerPositions.put(start, removeCaret(input.indexOf(start)))
+        markerPositions.put(end, removeCaret(input.indexOf(end)))
+        true
+      }
+    @tailrec
+    def detectNumberedMarkers(i: Int): Int =
+      if (detectMarker(startMarker(i), endMarker(i))) detectNumberedMarkers(i + 1) else i
+
+    val hasStartMarker  = detectMarker(startMarker, endMarker)
+    val index           = detectNumberedMarkers(0)
+    val adjustedMarkers = sortMarkers(markerPositions.toList.sortBy(_._2)).toMap
+
+    def addRange(start: String, end: String): Unit = {
+      input = input.replace(start, "")
+      input = input.replace(end, "")
+      textRanges += new TextRange(adjustedMarkers(start), adjustedMarkers(end))
+    }
+
+    if (hasStartMarker)
+      addRange(startMarker, endMarker)
+    for (i <- 0 until index) addRange(startMarker(i), endMarker(i))
+
+    input -> textRanges
+  }
+
+  def extractSequentialMarkers(inputText: String): (String, Seq[TextRange]) =
+    extractSequentialMarkers(inputText, startMarker, endMarker)
+
+  private def sortMarkers(sorted: List[(String, Int)], offset: Int = 0): List[(String, Int)] =
+    sorted match {
+      case (marker, position) :: tail => (marker, position - offset) :: sortMarkers(tail, offset + marker.length)
+      case _                          => sorted
+    }
+
+  /**
+   * Used to extract ranges that do not do not intersect
+   *
+   * @example
+   * line /start/ 1 content /end/
+   * line /start/ 2 /end/ /start/ content /end/
+   *
+   * TODO: reuse extractSequentialMarkers generic implementation
+   */
+  def extractSequentialMarkers(inputText: String, startMarker: String, endMarker: String): (String, Seq[TextRange]) = {
+    val ranges = findRanges(inputText, startMarker, endMarker)
+
+    val rangesFixed = ranges.zipWithIndex.map {
+      case (range, idx) =>
+        val alreadyRemovedChars = idx * (endMarker.length + startMarker.length)
+        val start               = range.getStartOffset - alreadyRemovedChars
+        val end                 = range.getEndOffset - alreadyRemovedChars - startMarker.length // plus first start marker
+        TextRange.create(start, end)
+    }
+
+    val textFixed = inputText.replace(startMarker, "").replace(endMarker, "")
+
+    (textFixed, rangesFixed)
+  }
+
+  def findRanges(inputText: String, startMarker: String, endMarker: String): Seq[TextRange] = {
+    val startReg = s"\\Q$startMarker\\E".r
+    val endReg   = s"\\Q$endMarker\\E".r
+
+    val startIndexes = startReg.findAllMatchIn(inputText).map(_.start).toList
+    val endIndexes   = endReg.findAllMatchIn(inputText).map(_.start).toList
+    assertEquals(
+      s"start & end markers counts are not equal\nstart: $startIndexes,\nend: $endIndexes\ntext: ${inputText}",
+      startIndexes.size,
+      endIndexes.size
+    )
+    val ranges = startIndexes.zip(endIndexes).map { case (s, e) => TextRange.create(s, e) }
+    ranges.foreach { range =>
+      assertTrue("range end offset can't be smaller then start offset", range.getEndOffset >= range.getStartOffset)
+    }
+    ranges.sliding(2).foreach {
+      case Seq(prev, curr) => assertTrue("ranges shouldn't intersect", curr.getStartOffset >= prev.getEndOffset)
+      case _               =>
+    }
+    ranges
+  }
+
+  /**
+   * Used to extract ranges that do not do not intersect, support
+   *
+   * @param inputText       example: {{{
+   *   line /start/ 1 content /end/
+   *   line <foldStart> 2 </foldEnd> [[ content ]]
+   * }}}
+   * @param startEndMarkers example: {{{
+   *   Seq(("/start/", "/end/"), ("<foldStart>", "<foldEnd>"), ("[[", "]]"))
+   * }}}
+   */
+  def extractSequentialMarkers(
+    inputText: String,
+    startEndMarkers: Seq[(String, String)]
+  ): (String, Seq[(TextRange, Int)]) = {
+    type MarkerType = Int
+
+    // marker selection ranges with marker types
+    val ranges: Seq[(TextRange, MarkerType)] = startEndMarkers.zipWithIndex.flatMap {
+      case ((startMarker, endMarker), markerType) =>
+        val startReg = s"\\Q$startMarker\\E".r
+        val endReg   = s"\\Q$endMarker\\E".r
+
+        val startMatches = startReg.findAllMatchIn(inputText).map(m => TextRange.create(m.start, m.end)).toSeq
+        val endMatches   = endReg.findAllMatchIn(inputText).map(m => TextRange.create(m.start, m.end)).toSeq
+
+        assertEquals(
+          s"start & end markers ($startMarker / $endMarker) counts are not equal\nstart: $startMatches,\nend: $endMatches",
+          startMatches.size,
+          endMatches.size
+        )
+
+        val ranges =
+          startMatches.zip(endMatches).map { case (s, e) => TextRange.create(s.getStartOffset, e.getStartOffset) }
+        ranges.foreach { range =>
+          assertTrue("range end offset can't be smaller then start offset", range.getEndOffset >= range.getStartOffset)
+        }
+
+        ranges.map(r => (r, markerType))
+    }
+
+    assertNonIntersecting(ranges.map(_._1))
+
+    val rangesFixed = ranges
+      .foldLeft(Seq.empty[(TextRange, MarkerType)], 0) {
+        case ((ranges, removedChars), (range, markerType)) =>
+          val (startMarker, endMarker) = startEndMarkers(markerType)
+
+          val start = range.getStartOffset - removedChars
+          val end   = range.getEndOffset - removedChars - startMarker.length
+
+          val rangesUpdated       = ranges :+ (TextRange.create(start, end), markerType)
+          val removedCharsUpdated = removedChars + startMarker.length + endMarker.length
+
+          (rangesUpdated, removedCharsUpdated)
+      }
+      ._1
+
+    assertNonIntersecting(rangesFixed.map(_._1))
+
+    // it is not most efficient way: we could build text by parts in the previous foldLeft and StringBuilder
+    // but it a little clear this way and doesn't matter much in tests cause it anyway costs milliseconds
+    val textFixed = startEndMarkers.foldLeft(inputText) {
+      case (text, (startMarker, endMarker)) =>
+        text.replace(startMarker, "").replace(endMarker, "")
+    }
+
+    (textFixed, rangesFixed)
+  }
+
+  private def assertNonIntersecting(ranges: Seq[TextRange]): Unit =
+    ranges.sliding(2).foreach {
+      case Seq(prev, curr) =>
+        assertTrue("ranges shouldn't intersect", curr.getStartOffset >= prev.getEndOffset)
+      case _ =>
+    }
+}
+
+object MarkersUtils extends Markers

--- a/src/test/scala/zio/intellij/searchers/ZioAccessorUsagesSearcherTest.scala
+++ b/src/test/scala/zio/intellij/searchers/ZioAccessorUsagesSearcherTest.scala
@@ -1,0 +1,644 @@
+package zio.intellij.searchers
+
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.util.PsiTreeUtil
+import intellij.testfixtures.RichStr
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
+import org.jetbrains.plugins.scala.base.libraryLoaders.{IvyManagedLoader, LibraryLoader}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
+import org.jetbrains.plugins.scala.util.Markers
+
+import scala.collection.JavaConverters._
+
+class ZioAccessorUsagesSearcherTest extends ScalaLightCodeInsightFixtureTestAdapter with Markers {
+
+  protected val zioOrg     = "dev.zio"
+  protected val zioVersion = "latest.integration"
+
+  override def librariesLoaders: Seq[LibraryLoader] =
+    super.librariesLoaders :+ IvyManagedLoader(zioOrg %% "zio" % zioVersion, zioOrg %% "zio-macros" % zioVersion)
+
+  private def doTest(fileText: String): Unit = {
+
+    val (source, expectedUsageRanges) = extractMarkers(StringUtil.convertLineSeparators(fileText))
+
+    configureFromFileText(source)
+
+    val elem  = myFixture.getElementAtCaret
+    val named = PsiTreeUtil.getParentOfType(elem, classOf[ScNamedElement], false)
+
+    val foundUsages = myFixture.findUsages(named).asScala.map(_.getElement.getTextRange).toSet
+
+    val expectedButNotFound = expectedUsageRanges.filterNot(foundUsages.contains)
+    val foundButNotExpected = foundUsages.filterNot(expectedUsageRanges.contains)
+
+    assert(
+      expectedButNotFound.isEmpty,
+      s"Didn't find ${expectedButNotFound.mkString(", ")} but found ${foundButNotExpected.mkString(", ")}"
+    )
+    assert(foundButNotExpected.isEmpty, s"Found but didn't expect ${foundButNotExpected.mkString(", ")}")
+  }
+
+  def base(s: String): String =
+    s"""import zio._
+       |import zio.macros.accessible
+       |
+       |
+       |$s
+       |""".stripMargin
+
+  // Two simple checks for zio macros
+  // It should work fine if regular `find usages` works fine
+  def testMacrosVal(): Unit =
+    doTest(base(s"""@accessible
+                   |object FindMyAccessors {
+                   |  trait Service {
+                   |    val method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testMacrosDef(): Unit =
+    doTest(base(s"""@accessible
+                   |object FindMyAccessors {
+                   |  trait Service {
+                   |    def method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindValZioValZio(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    val method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindDefZioDefZio(): Unit =
+    doTest(base(s"""
+                   |import zio._
+                   |object FindMyAccessors {
+                   |  def method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindValZioVal(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    val method$caretText: Int = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindDefZioDef(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText: Int = ???
+                   |  }
+                   |}
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindValValZio(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: Int = ???
+                   |  trait Service {
+                   |    val method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefDefZio(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: Int = ???
+                   |  trait Service {
+                   |    def method$caretText: UIO[Int] = ???
+                   |  }
+                   |}
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindValVal(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: Int = ???
+                   |  trait Service {
+                   |    val method$caretText: Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefDef(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: Int = ???
+                   |  trait Service {
+                   |    def method$caretText: Int = ???
+                   |  }
+                   |}
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefZioDefZioOneArgSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("")
+      """.stripMargin))
+
+  def testFindDefZioDefZioOneArgDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefZioDefZioTwoArgsSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("", 1)
+      """.stripMargin))
+
+  def testFindDefZioDefZioTwoArgsDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefZioDefOneArgSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): Int = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("")
+      """.stripMargin))
+
+  def testFindDefZioDefOneArgDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefZioDefTwoArgsSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("", 1)
+      """.stripMargin))
+
+  def testFindDefZioDefTwoArgsDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefDefZioOneArgSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefZioOneArgDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefZioTwoArgsSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("", 1)
+      """.stripMargin))
+
+  def testFindDefDefZioTwoArgsDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int] = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefDefOneArgSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefOneArgDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefTwoArgsSame(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("", 1)
+      """.stripMargin))
+
+  def testFindDefDefTwoArgsDiff(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int = ???
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindValZioValZioAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    val method$caretText: UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindDefZioDefZioAbstract(): Unit =
+    doTest(base(s"""
+                   |import zio._
+                   |object FindMyAccessors {
+                   |  def method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText: UIO[Int]
+                   |  }
+                   |}
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindValZioValAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    val method$caretText: Int
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindDefZioDefAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText: Int
+                   |  }
+                   |}
+                   |${start}FindMyAccessors.method$end
+      """.stripMargin))
+
+  def testFindValValZioAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: Int = ???
+                   |  trait Service {
+                   |    val method$caretText: UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefDefZioAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: Int = ???
+                   |  trait Service {
+                   |    def method$caretText: UIO[Int]
+                   |  }
+                   |}
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindValValAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  val method: Int = ???
+                   |  trait Service {
+                   |    val method$caretText: Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefDefAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method: Int = ???
+                   |  trait Service {
+                   |    def method$caretText: Int
+                   |  }
+                   |}
+                   |FindMyAccessors.method
+      """.stripMargin))
+
+  def testFindDefZioDefZioOneArgSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("")
+      """.stripMargin))
+
+  def testFindDefZioDefZioOneArgDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefZioDefZioTwoArgsSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("", 1)
+      """.stripMargin))
+
+  def testFindDefZioDefZioTwoArgsDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefZioDefOneArgSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): Int
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("")
+      """.stripMargin))
+
+  def testFindDefZioDefOneArgDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefZioDefTwoArgsSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int
+                   |  }
+                   |}
+                   |
+                   |${start}FindMyAccessors.method$end("", 1)
+      """.stripMargin))
+
+  def testFindDefZioDefTwoArgsDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): URIO[Has[Service], Int] = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefDefZioOneArgSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefZioOneArgDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefZioTwoArgsSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("", 1)
+      """.stripMargin))
+
+  def testFindDefDefZioTwoArgsDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): UIO[Int]
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+  def testFindDefDefOneArgSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String): Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefOneArgDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: Int): Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("")
+      """.stripMargin))
+
+  def testFindDefDefTwoArgsSameAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: String, arg2: Int): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int): Int
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method("", 1)
+      """.stripMargin))
+
+  def testFindDefDefTwoArgsDiffAbstract(): Unit =
+    doTest(base(s"""
+                   |object FindMyAccessors {
+                   |  def method(arg1: Int, arg2: String): Int = ???
+                   |  trait Service {
+                   |    def method$caretText(arg1: String, arg2: Int)
+                   |  }
+                   |}
+                   |
+                   |FindMyAccessors.method(1, "")
+      """.stripMargin))
+
+}


### PR DESCRIPTION
Closes https://github.com/zio/zio-intellij/issues/131.
There are two problems that I failed to solve.
1) Before searching for method usages, ask the user whether he wants to find accessor usages as well. It seems like this would require to override FindUsagesHandler from the Scala plugin, which doesn't seem like a good idea. Therefore, the plugin always searches for usages of the accessor method.
2) I've faced some weird bug when I try to rename the method that has an accessor. Intellij renames the method and all of its usages (including accessor usages), but it does not rename the accessor itself. I have no idea how to fix this :)

However, other things work fine. Searcher in this PR works both with the explicit accessors and with the accessors created by `accessible` macros. It also contains a few tests in case if someone decides to fix the mentioned problems :)