### PR TITLE
Better detection of ZIO Test framework

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/package.scala
+++ b/src/main/scala/zio/intellij/testsupport/package.scala
@@ -19,8 +19,8 @@ package object testsupport {
 
   def detectZTestFramework(c: PsiClass): Option[TestFramework] =
     Option(TestFrameworks.detectFramework(c)) match {
-      case Some(framework) if framework.isTestClass(c) => Some(framework)
-      case _                                           => None
+      case Some(framework: ZTestFramework) if framework.isTestClass(c) => Some(framework)
+      case _                                                           => None
     }
 
   object testName {


### PR DESCRIPTION
Fixes #157

Backporting this to 2020.1.x, because this fixes an annoyance with the Bazel plugin, but Bazel does not support the latest IntelliJ versions yet.
