### PR TITLE
Configure running tests from sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,8 @@ lazy val `zio-intellij` = project
       "com.intellij.java".toPlugin,
       "org.intellij.scala:2020.2.25".toPlugin
     ),
+    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-s", "-a", "+c", "+q"),
     patchPluginXml := pluginXmlOptions { xml =>
       xml.version = version.value
       xml.changeNotes = s"""<![CDATA[


### PR DESCRIPTION
This allows running `sbt test`, `sbt testOnly *TestClass`, etc.

The only problem is that if at least one test fails, we get quite a lot of DEBUG level logs from IntelliJ classes.
As far as I know, the IntelliJ test framework defines a custom logger that always uses the DEBUG level for most non-performance tests:
```
public boolean isDebugEnabled() {
  if (ApplicationInfoImpl.isInStressTest()) {
    return super.isDebugEnabled();
  }
  return true;
}
```

I could not override this yet, and I'm not sure if it's even possible without dirty hacks.