### PR TITLE
Per-version inspection toggle

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,6 @@
 
     <extensions defaultExtensionNs="org.intellij.scala">
         <syntheticMemberInjector implementation="zio.intellij.synthetic.macros.ModulePatternAccessible"/>
-
         <syntheticMemberInjector implementation="zio.intellij.synthetic.macros.MockableInjector"/>
     </extensions>
 

--- a/src/main/scala/zio/intellij/inspections/ZInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/ZInspection.scala
@@ -1,7 +1,13 @@
 package zio.intellij.inspections
 
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
 import javax.swing.JComponent
+import org.jetbrains.plugins.scala.codeInspection.collections.OperationOnCollectionInspectionBase.SimplifiableExpression
 import org.jetbrains.plugins.scala.codeInspection.collections._
+import org.jetbrains.plugins.scala.lang.psi.ScalaPsiUtil
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+import zio.intellij.utils.{ModuleSyntax, Version}
 
 abstract class ZInspection(simplifiers: SimplificationType*) extends OperationOnCollectionInspection {
   final override def getLikeCollectionClasses: Array[String] = Array("zio.ZIO")
@@ -9,4 +15,34 @@ abstract class ZInspection(simplifiers: SimplificationType*) extends OperationOn
   final override def createOptionsPanel(): JComponent = null // god help me
 
   final override def possibleSimplificationTypes: Array[SimplificationType] = simplifiers.toArray
+
+  protected def isAvailable(zioVersion: Version): Boolean = zioVersion >= Version.ZIO.`1.0.0`
+
+  private def isInspectionAvailable(inspection: ZInspection, element: PsiElement): Boolean = {
+    Option(ScalaPsiUtil.getModule(element))
+      .flatMap(_.zioVersion)
+      .exists(zioVersion => inspection.isAvailable(zioVersion))
+  }
+
+  protected override def actionFor(implicit
+    holder: ProblemsHolder,
+    isOnTheFly: Boolean
+  ): PartialFunction[PsiElement, Any] = {
+    case SimplifiableExpression(expr) if isInspectionAvailable(this, expr) =>
+      simplifications(expr).foreach {
+        case s @ Simplification(toReplace, _, hint, rangeInParent) =>
+          val quickFix = OperationOnCollectionQuickFix(s)
+          holder.registerProblem(toReplace.getElement, hint, highlightType, rangeInParent, quickFix)
+      }
+  }
+
+  private def simplifications(expr: ScExpression): Array[Simplification] = {
+    def simplificationTypes = for {
+      (st, idx) <- possibleSimplificationTypes.zipWithIndex
+      if simplificationTypesEnabled(idx)
+    } yield st
+
+    simplificationTypes.flatMap(st => st.getSimplifications(expr) ++ st.getSimplification(expr))
+  }
+
 }

--- a/src/main/scala/zio/intellij/inspections/mistakes/UnusedZIOExpressionsInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/UnusedZIOExpressionsInspection.scala
@@ -17,7 +17,7 @@ class UnusedZIOExpressionsInspection extends AbstractRegisteredInspection {
     highlightType: ProblemHighlightType
   )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
     element match {
-      case expr: ScExpression if IntentionAvailabilityChecker.checkInspection(this, expr.getParent) =>
+      case expr: ScExpression =>
         (expr, Option(expr.getNextSiblingNotWhitespace)) match {
           case (zioRef(_, _), Some(zioRef(_, _))) =>
             Some(

--- a/src/main/scala/zio/intellij/inspections/mistakes/YieldingZIOEffectInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/YieldingZIOEffectInspection.scala
@@ -46,7 +46,7 @@ class YieldingZIOEffectInspection extends AbstractRegisteredInspection {
     highlightType: ProblemHighlightType
   )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
     element match {
-      case expr: ScFor if IntentionAvailabilityChecker.checkInspection(this, expr.getParent) =>
+      case expr: ScFor =>
         expr.body match {
           case Some(body @ zioRef(_, _)) if hasGeneratorFromSameClass(expr, body) =>
             Some(createDescriptor(body))

--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
@@ -27,7 +27,7 @@ import org.jetbrains.plugins.scala.testingSupport.test._
 import org.jetbrains.plugins.scala.testingSupport.test.actions.ScalaRerunFailedTestsAction
 import org.jetbrains.plugins.scala.testingSupport.test.sbt._
 import org.jetbrains.plugins.scala.testingSupport.test.testdata.{ClassTestData, TestConfigurationData}
-
+import zio.intellij.utils._
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -67,15 +67,7 @@ class ZTestRunConfiguration(
     runnerInfo.runnerClass == ZTestRunnerName
 
   private def hasTestRunner(module: Module): Boolean =
-    if (BspUtil.isBspModule(module)) {
-      // todo there must be a better way!
-      val allFiles = module.libraries
-        .flatMap(_.getUrls(OrderRootType.CLASSES))
-        .toSet
-
-      allFiles.exists(_.contains("zio-test-intellij"))
-    } else
-      module.libraries.map(_.getName).exists(_.contains("zio-test-intellij"))
+    module.findLibrary(_.contains("zio-test-intellij")).isDefined
 
   override def getState(executor: Executor, env: ExecutionEnvironment): RunProfileState = {
     val module = getModule

--- a/src/main/scala/zio/intellij/utils/Version.scala
+++ b/src/main/scala/zio/intellij/utils/Version.scala
@@ -81,6 +81,6 @@ object Version {
     val RC19: Version     = Version.parseUnsafe("1.0.0-RC19")
     val RC21: Version     = Version.parseUnsafe("1.0.0-RC21")
     val `RC21-2`: Version = Version.parseUnsafe("1.0.0-RC21-2")
+    val `1.0.0`: Version  = Version.parseUnsafe("1.0.0")
   }
-
 }


### PR DESCRIPTION
Fixes #102 

This solves the immediate problem by allowing to specify `availableSince` version, however this adds an extra minute to the test run, meaning this could affect performance. Need to investigate caching.