### PR TITLE
Detecting test method by their return type signature instead of the name

### DIFF
--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -8,22 +8,11 @@ import org.jetbrains.plugins.scala.annotator.usageTracker.ScalaRefCountHolder
 import org.jetbrains.plugins.scala.extensions.PsiClassExt
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
-import org.jetbrains.plugins.scala.lang.psi.api.statements.{
-  ScFunction,
-  ScFunctionDeclaration,
-  ScFunctionDefinition,
-  ScTypeAliasDefinition
-}
+import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScNamedElement, ScTypedDefinition}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
-import org.jetbrains.plugins.scala.lang.psi.types.{
-  AliasType,
-  PhysicalMethodSignature,
-  ScParameterizedType,
-  ScType,
-  TermSignature
-}
+import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
 
 package object utils {


### PR DESCRIPTION
Allows for using custom test methods that run specs