### PR TITLE
Add `CanFail` support

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -177,6 +177,30 @@
                          shortName="SimplifyBuildUseInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.InfallibleEffectRecoveryInspection"
+                         displayName="Effect cannot fail; operation on error is impossible"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="InfallibleEffectRecoveryInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyErrorModificationInspection"
+                         displayName="Simplify expression by discarding operation on error since effect cannot fail"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifyErrorModificationInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyErrorRecoveryInspection"
+                         displayName="Simplify expression by discarding recovery since effect cannot fail"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifyErrorRecoveryInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyErrorSeparationInspection"
+                         displayName="Simplify expression by discarding operation on error since effect cannot fail"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifyErrorSeparationInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>

--- a/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
+++ b/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
@@ -9,7 +9,7 @@ for {
 } yield ???
 </pre>
 <br/>
-Аnd you will also be prompted to fix it using <code>ZIO.when</code>:
+And you will also be prompted to fix it using <code>ZIO.when</code>:
 <pre>
 for {
     _ <- myService.executeSomething().when(config.somethingShouldBeExecuted)

--- a/src/main/resources/inspectionDescriptions/InfallibleEffectRecoveryInspection.html
+++ b/src/main/resources/inspectionDescriptions/InfallibleEffectRecoveryInspection.html
@@ -1,0 +1,26 @@
+<html>
+Detects usages of methods that require `CanFail` evidence on infallible effects.
+For example
+<pre>
+    val task: Task[Int] = Task(1)
+    val uio: UIO[Int]   = UIO(1)
+
+    task.option      // 1
+    uio.option       // 2
+
+    task.orElse(uio) // 3
+    uio.orElse(task) // 4
+</pre>
+Lines 1 and 3 will not be highlighted since it is a valid code.
+<br/>
+Lines 2 and 4 will be highlighted since uio can't fail, which means `.option` and `.orElse` doesn't make sense and this
+code will not compile.
+<br/>
+Faulty operations can be discarded automatically (see <a href="https://zio.dev/docs/can_fail">ZIO documentation</a>),
+e.g.
+<pre>
+    uio.option            => uio
+    uio.orElse(task)      => uio
+    uio.flatMapError(???) => uio
+</pre>
+</html>

--- a/src/main/resources/inspectionDescriptions/SimplifyErrorModificationInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifyErrorModificationInspection.html
@@ -1,0 +1,14 @@
+<html>
+Detects operations on both value and error if the effect cannot fail and suggest simplification that will keep only
+operation on value.
+<pre>
+    val uio: UIO[Int] = UIO(1)
+
+    uio.bimap(e => f(e), v => g(v))      => uio.map(v => g(v))
+    uio.tapBoth(e => f(e), v => g(v))    => uio.tap(v => g(v))
+    uio.fold(e => f(e), v => g(v))       => uio.map(v => g(v))
+    uio.foldM(e => f(e), v => g(v))      => uio.flatMap(v => g(v))
+    uio.foldTraceM(e => f(e), v => g(v)) => uio.flatMap(v => g(v))
+</pre>
+See <a href="https://zio.dev/docs/can_fail">ZIO documentation</a> for explanation and more examples.
+</html>

--- a/src/main/resources/inspectionDescriptions/SimplifyErrorRecoveryInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifyErrorRecoveryInspection.html
@@ -1,0 +1,15 @@
+<html>
+Detects recovery from error if the effect cannot fail and suggest simplification that will keep the same type without
+recovery.
+<pre>
+    val uio: UIO[Int]   = UIO(1)
+    val task: Task[Int] = Task(1)
+
+    uio.option                      => uio.map(Some(_))
+    uio.either                      => uio.map(Right(_))
+    uio.orElseEither(task)          => uio.map(Left(_))
+    uio <+> task                    => uio.map(Left(_))
+    uio.retryOrElseEither(???, ???) => uio.map(Right(_))
+</pre>
+See <a href="https://zio.dev/docs/can_fail">ZIO documentation</a> for explanation and more examples.
+</html>

--- a/src/main/resources/inspectionDescriptions/SimplifyErrorSeparationInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifyErrorSeparationInspection.html
@@ -1,0 +1,18 @@
+<html>
+Detects operations that will separate successes and failures when working with collections and suggest simplification
+that does not use errors. Note that these simplifications may change the behavior and may differ in return type.
+<pre>
+    val n: Int = 1
+    val list: List[Int] = Nil
+    val func(i: Int): UIO[Int] = UIO(i)
+
+    ZIO.partition(list)(func)        => ZIO.foreach(list)(func)
+    ZIO.partitionPar(list)(func)     => ZIO.foreachPar(list)(func)
+    ZIO.partitionParN(n)(list)(func) => ZIO.foreachParN(n)(list)(func)
+    ZIO.validate(list)(func)         => ZIO.foreach(list)(func)
+    ZIO.validatePar(list)(func)      => ZIO.foreachPar(list)(func)
+    ZIO.validateFirst(list)(func)    => ZIO.foreach(list)(func)
+    ZIO.validateFirstPar(list)(func) => ZIO.foreachPar(list)(func)
+</pre>
+See <a href="https://zio.dev/docs/can_fail">ZIO documentation</a> for explanation and more examples.
+</html>

--- a/src/main/scala/zio/intellij/inspections/mistakes/InfallibleEffectRecoveryInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/InfallibleEffectRecoveryInspection.scala
@@ -1,0 +1,73 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection.{InspectionManager, LocalQuickFix, ProblemDescriptor, ProblemHighlightType}
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.collections.MethodRepr
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractRegisteredInspection}
+import org.jetbrains.plugins.scala.lang.psi.api.base.ScReference
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.types.api.ParameterizedType
+import org.jetbrains.plugins.scala.lang.psi.types.result.Typeable
+import zio.intellij.inspections._
+import zio.intellij.inspections.mistakes.InfallibleEffectRecoveryInspection._
+import zio.intellij.utils.{OptionUtils => OptionOps, _}
+
+class InfallibleEffectRecoveryInspection extends AbstractRegisteredInspection {
+
+  private def canFailDesignator(context: PsiElement): Option[ScType] =
+    createType("_root_.zio.CanFail", context)
+
+  private def isCanFailEv(element: PsiElement): Boolean =
+    element match {
+      case Typeable(ParameterizedType(designator, _)) => canFailDesignator(element).exists(_.equiv(designator))
+      case _                                          => false
+    }
+
+  private def isInfallibleEffect(zio: ScExpression): Boolean =
+    zio match {
+      case Typeable(`URIO[R, A]`(_, _)) => true
+      case _                            => false
+    }
+
+  override protected def problemDescriptor(
+    element: PsiElement,
+    maybeQuickFix: Option[LocalQuickFix],
+    descriptionTemplate: String,
+    highlightType: ProblemHighlightType
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
+    element match {
+      case MethodRepr(expr, Some(base), Some(ref), _) if isInfallibleEffect(base) =>
+        expr.findImplicitArguments.flatMap { args =>
+          OptionOps.when(args.map(_.element).exists(isCanFailEv))(createFix(expr, base, ref))
+        }
+      case _ => None
+    }
+}
+
+object InfallibleEffectRecoveryInspection {
+  def hint(toDelete: String) = s"Remove unreachable .$toDelete"
+
+  def description(toDelete: String) =
+    s"Effect cannot fail; operation .$toDelete is impossible"
+
+  def createFix(
+    expr: ScExpression,
+    base: ScExpression,
+    toDelete: ScReference
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): ProblemDescriptor =
+    manager.createProblemDescriptor(
+      expr,
+      description(toDelete.refName),
+      isOnTheFly,
+      Array[LocalQuickFix](new RecoveryQuickFix(expr, base, toDelete.refName)),
+      ProblemHighlightType.GENERIC_ERROR
+    )
+
+  final private class RecoveryQuickFix(expr: ScExpression, base: ScExpression, toDelete: String)
+      extends AbstractFixOnPsiElement(hint(toDelete), expr) {
+    override protected def doApplyFix(expr: ScExpression)(implicit project: Project): Unit =
+      expr.replace(base)
+  }
+}

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -8,8 +8,9 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTemplateDefinition}
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import zio.intellij.utils.TypeCheckUtils._
-import zio.intellij.utils.fqnIfIsOfClassFrom
+import zio.intellij.utils._
 import zio.intellij.utils.types._
 
 package object inspections {
@@ -19,22 +20,31 @@ package object inspections {
   }
 
   object zioMethods {
-    val `.*>` : Qualified          = invocation("*>").from(zioLikePackages)
-    val `.as`: Qualified           = invocation("as").from(zioLikePackages)
-    val `.map`: Qualified          = invocation("map").from(zioLikePackages)
-    val `.flatMap`: Qualified      = invocation("flatMap").from(zioLikePackages)
-    val `.flatMapError`: Qualified = invocation("flatMapError").from(zioLikePackages)
-    val `.mapError`: Qualified     = invocation("mapError").from(zioLikePackages)
-    val `.orElse`: Qualified       = invocation("orElse").from(zioLikePackages)
-    val `.orElseFail`: Qualified   = invocation("orElseFail").from(zioLikePackages)
-    val `.catchAll`: Qualified     = invocation("catchAll").from(zioLikePackages)
-    val `.fold`: Qualified         = invocation("fold").from(zioLikePackages)
-    val `.foldCause`: Qualified    = invocation("foldCause").from(zioLikePackages)
-    val `.foldCauseM`: Qualified   = invocation("foldCauseM").from(zioLikePackages)
-    val `.tap`: Qualified          = invocation("tap").from(zioLikePackages)
-    val `.tapError`: Qualified     = invocation("tapError").from(zioLikePackages)
-    val `.orDie`: Qualified        = invocation("orDie").from(zioLikePackages)
-    val `.provide`: Qualified      = invocation("provide").from(zioLikePackages)
+    val `.*>` : Qualified               = invocation("*>").from(zioLikePackages)
+    val `.as`: Qualified                = invocation("as").from(zioLikePackages)
+    val `.map`: Qualified               = invocation("map").from(zioLikePackages)
+    val `.flatMap`: Qualified           = invocation("flatMap").from(zioLikePackages)
+    val `.flatMapError`: Qualified      = invocation("flatMapError").from(zioLikePackages)
+    val `.mapError`: Qualified          = invocation("mapError").from(zioLikePackages)
+    val `.bimap`: Qualified             = invocation("bimap").from(zioLikePackages)
+    val `.orElse`: Qualified            = invocation("orElse").from(zioLikePackages)
+    val `.orElseFail`: Qualified        = invocation("orElseFail").from(zioLikePackages)
+    val `.orElseEither`: Qualified      = invocation("orElseEither").from(zioLikePackages)
+    val `.<+>` : Qualified              = invocation("<+>").from(zioLikePackages)
+    val `.retryOrElseEither`: Qualified = invocation("retryOrElseEither").from(zioLikePackages)
+    val `.catchAll`: Qualified          = invocation("catchAll").from(zioLikePackages)
+    val `.fold`: Qualified              = invocation("fold").from(zioLikePackages)
+    val `.foldM`: Qualified             = invocation("foldM").from(zioLikePackages)
+    val `.foldCause`: Qualified         = invocation("foldCause").from(zioLikePackages)
+    val `.foldCauseM`: Qualified        = invocation("foldCauseM").from(zioLikePackages)
+    val `.foldTraceM`: Qualified        = invocation("foldTraceM").from(zioLikePackages)
+    val `.tap`: Qualified               = invocation("tap").from(zioLikePackages)
+    val `.tapError`: Qualified          = invocation("tapError").from(zioLikePackages)
+    val `.tapBoth`: Qualified           = invocation("tapBoth").from(zioLikePackages)
+    val `.orDie`: Qualified             = invocation("orDie").from(zioLikePackages)
+    val `.provide`: Qualified           = invocation("provide").from(zioLikePackages)
+    val `.option`: Qualified            = invocation("option").from(zioLikePackages)
+    val `.either`: Qualified            = invocation("either").from(zioLikePackages)
 
     val `.fork`: Qualified                 = invocation("fork").from(zioLikePackages)
     val `.forkDaemon`: Qualified           = invocation("forkDaemon").from(zioLikePackages)
@@ -254,11 +264,18 @@ package object inspections {
   val `ZIO.forkAll`       = new ZIOStaticMemberReference("forkAll")
   val `ZIO.forkAll_`      = new ZIOStaticMemberReference("forkAll_")
 
-  val `ZIO.collectAllParN` = new ZIOCurried2StaticMemberReference("collectAllParN")
-  val `ZIO.foreach`        = new ZIOCurried2StaticMemberReference("foreach")
-  val `ZIO.foreachPar`     = new ZIOCurried2StaticMemberReference("foreachPar")
+  val `ZIO.collectAllParN`   = new ZIOCurried2StaticMemberReference("collectAllParN")
+  val `ZIO.foreach`          = new ZIOCurried2StaticMemberReference("foreach")
+  val `ZIO.foreachPar`       = new ZIOCurried2StaticMemberReference("foreachPar")
+  val `ZIO.partition`        = new ZIOCurried2StaticMemberReference("partition")
+  val `ZIO.partitionPar`     = new ZIOCurried2StaticMemberReference("partitionPar")
+  val `ZIO.validate`         = new ZIOCurried2StaticMemberReference("validate")
+  val `ZIO.validatePar`      = new ZIOCurried2StaticMemberReference("validatePar")
+  val `ZIO.validateFirst`    = new ZIOCurried2StaticMemberReference("validateFirst")
+  val `ZIO.validateFirstPar` = new ZIOCurried2StaticMemberReference("validateFirstPar")
 
-  val `ZIO.foreachParN` = new ZIOCurried3StaticMemberReference("foreachParN")
+  val `ZIO.foreachParN`   = new ZIOCurried3StaticMemberReference("foreachParN")
+  val `ZIO.partitionParN` = new ZIOCurried3StaticMemberReference("partitionParN")
 
   val `ZLayer.fromEffect`     = new ZLayerStaticMemberReference("fromEffect")
   val `ZLayer.fromEffectMany` = new ZLayerStaticMemberReference("fromEffectMany")
@@ -378,6 +395,25 @@ package object inspections {
             case _                                           => None
           }
         case _ => None
+      }
+  }
+
+  object `ZIO[R, E, A]` {
+    private def unapplyInner(tpe: ScType): Option[(ScType, ScType, ScType)] =
+      resolveAliases(tpe.tryExtractDesignatorSingleton).flatMap(extractTypeArguments).flatMap {
+        case Seq(r, e, a) => Some(r, e, a)
+        case _            => None
+      }
+
+    def unapply(tpe: ScType): Option[(ScType, ScType, ScType)] =
+      if (fromZio(tpe)) unapplyInner(tpe) else None
+  }
+
+  object `URIO[R, A]` {
+    def unapply(tpe: ScType): Option[(ScType, ScType)] =
+      tpe match {
+        case `ZIO[R, E, A]`(r, e, a) if e.isNothing => Some(r, a)
+        case _                                      => None
       }
   }
 }

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyInfallibleEffectInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyInfallibleEffectInspection.scala
@@ -1,0 +1,189 @@
+package zio.intellij.inspections.simplifications
+
+import org.jetbrains.plugins.scala.codeInspection.collections.{
+  invocationText,
+  Qualified,
+  Simplification,
+  SimplificationType
+}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScReferenceExpression}
+import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunction
+import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.types.result.{TypeResult, Typeable}
+import zio.intellij.inspections._
+import zio.intellij.inspections.zioMethods._
+import zio.intellij.utils.StringUtils.ScExpressionExt
+import zio.intellij.utils._
+import zio.intellij.utils.types.ZioType
+
+class SimplifyErrorModificationInspection
+    extends ZInspection(
+      BimapErrorModificationSimplificationType,
+      TapBothErrorModificationSimplificationType,
+      FoldErrorModificationSimplificationType,
+      FoldMErrorModificationSimplificationType,
+      FoldTraceMErrorModificationSimplificationType
+    )
+
+class SimplifyErrorRecoveryInspection
+    extends ZInspection(
+      OptionErrorRecoverySimplificationType,
+      EitherErrorRecoverySimplificationType,
+      OrElseEitherErrorRecoverySimplificationType,
+      OrElseEitherAliasErrorRecoverySimplificationType,
+      RetryOrElseEitherErrorRecoverySimplificationType
+    )
+
+class SimplifyErrorSeparationInspection
+    extends ZInspection(
+      PartitionErrorSeparationSimplificationType,
+      PartitionParErrorSeparationSimplificationType,
+      PartitionParNErrorSeparationSimplificationType,
+      ValidateErrorSeparationSimplificationType,
+      ValidateParErrorSeparationSimplificationType,
+      ValidateFirstErrorSeparationSimplificationType,
+      ValidateFirstParErrorSeparationSimplificationType
+    )
+
+sealed abstract class BaseInfallibleEffectSimplificationType extends SimplificationType {
+  final protected def isURIO(tpe: ScType): Boolean =
+    tpe match {
+      case `URIO[R, A]`(_, _) => true
+      case _                  => false
+    }
+
+  final protected def isURIO(tpe: TypeResult): Boolean =
+    isURIO(tpe.getOrAny)
+
+  final protected def isURIO(zio: ScExpression): Boolean =
+    isURIO(zio.`type`)
+
+  final protected def isURIOFunc(func: ScExpression): Boolean =
+    func match {
+      // zio.flatMap(foo)
+      case ScReferenceExpression(f: ScFunction) => isURIO(f.returnType)
+      /* workaround for
+          val foo: Any => UIO[Any] = ???
+          zio.flatMap(foo)
+       */
+      case ScReferenceExpression(Typeable(funcType)) =>
+        extractTypeArguments(funcType).flatMap(_.lastOption).exists(isURIO)
+      // zio.flatMap(el => foo(el))
+      case lambda(_, res) => isURIO(res.`type`)
+      // zio.flatMap(foo(_))
+      case expr => isURIO(expr.getNonValueType(fromUnderscore = true))
+    }
+}
+
+sealed abstract class BaseErrorModificationSimplificationType(qual: Qualified, methodName: String)
+    extends BaseInfallibleEffectSimplificationType {
+
+  val hint = s"Replace with .$methodName"
+
+  private def replacement(expr: ScExpression, zio: ScExpression, g: ScExpression): Simplification =
+    replace(expr).withText(invocationText(zio, methodName, g)).highlightAll
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case qual(zio, _, g) if isURIO(zio) => Some(replacement(expr, zio, g))
+      case _                              => None
+    }
+
+}
+
+object BimapErrorModificationSimplificationType   extends BaseErrorModificationSimplificationType(`.bimap`, "map")
+object TapBothErrorModificationSimplificationType extends BaseErrorModificationSimplificationType(`.tapBoth`, "tap")
+
+object FoldErrorModificationSimplificationType  extends BaseErrorModificationSimplificationType(`.fold`, "map")
+object FoldMErrorModificationSimplificationType extends BaseErrorModificationSimplificationType(`.foldM`, "flatMap")
+object FoldTraceMErrorModificationSimplificationType
+    extends BaseErrorModificationSimplificationType(`.foldTraceM`, "flatMap")
+
+sealed abstract class BaseErrorRecoverySimplificationType(qual: Qualified, methodStr: String)
+    extends BaseInfallibleEffectSimplificationType {
+
+  val hint = s"Replace with .map($methodStr)"
+
+  private def replacement(expr: ScExpression, zio: ScExpression): Option[Simplification] =
+    createExpression(methodStr, expr).map(m => replace(expr).withText(invocationText(zio, "map", m)).highlightAll)
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case qual(zio, _*) if isURIO(zio) => replacement(expr, zio)
+      case _                            => None
+    }
+
+}
+
+object OptionErrorRecoverySimplificationType extends BaseErrorRecoverySimplificationType(`.option`, "Some(_)")
+object EitherErrorRecoverySimplificationType extends BaseErrorRecoverySimplificationType(`.either`, "Right(_)")
+// `Left(_)` is not a mistake here. Props to consistent API.
+object OrElseEitherErrorRecoverySimplificationType
+    extends BaseErrorRecoverySimplificationType(`.orElseEither`, "Left(_)")
+object OrElseEitherAliasErrorRecoverySimplificationType extends BaseErrorRecoverySimplificationType(`.<+>`, "Left(_)")
+object RetryOrElseEitherErrorRecoverySimplificationType
+    extends BaseErrorRecoverySimplificationType(`.retryOrElseEither`, "Right(_)")
+
+sealed abstract class BaseErrorSeparationSimplificationType(
+  qual: ZIOCurried2StaticMemberReference,
+  methodName: String
+) extends BaseInfallibleEffectSimplificationType {
+
+  val hint = s"Replace with ZIO.$methodName"
+
+  protected def replacement(
+    zioType: ZioType,
+    expr: ScExpression,
+    iterable: ScExpression,
+    func: ScExpression
+  ): Simplification =
+    replace(expr).withText(s"${zioType.name}.$methodName${iterable.getWrappedText}${func.getWrappedText}").highlightAll
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case qual(zioType, iterable, func) if isURIOFunc(func) => Some(replacement(zioType, expr, iterable, func))
+      case _                                                 => None
+    }
+
+}
+
+object PartitionErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.partition`, "foreach")
+object PartitionParErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.partitionPar`, "foreachPar")
+object ValidateErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.validate`, "foreach")
+object ValidateParErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.validatePar`, "foreachPar")
+object ValidateFirstErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.validateFirst`, "foreach")
+object ValidateFirstParErrorSeparationSimplificationType
+    extends BaseErrorSeparationSimplificationType(`ZIO.validateFirstPar`, "foreachPar")
+
+object PartitionParNErrorSeparationSimplificationType extends BaseInfallibleEffectSimplificationType {
+
+  private val qual: ZIOCurried3StaticMemberReference = `ZIO.partitionParN`
+
+  private val methodName = "foreachParN"
+
+  val hint = s"Replace with ZIO.$methodName"
+
+  protected def replacement(
+    zioType: ZioType,
+    expr: ScExpression,
+    n: ScExpression,
+    iterable: ScExpression,
+    func: ScExpression
+  ): Simplification =
+    replace(expr)
+      .withText(s"${zioType.name}.$methodName${n.getWrappedText}${iterable.getWrappedText}${func.getWrappedText}")
+      .highlightAll
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case qual(zioType, n, iterable, func) if isURIOFunc(func) =>
+        Some(replacement(zioType, expr, n, iterable, func))
+      case _ => None
+    }
+
+}

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -8,6 +8,7 @@ import org.jetbrains.plugins.scala.annotator.usageTracker.ScalaRefCountHolder
 import org.jetbrains.plugins.scala.extensions.PsiClassExt
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
 import org.jetbrains.plugins.scala.lang.psi.api.statements._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.{ScNamedElement, ScTypedDefinition}
@@ -64,6 +65,9 @@ package object utils {
 
   def createType(text: String, context: PsiElement, child: PsiElement = null): Option[ScType] =
     ScalaPsiElementFactory.createTypeFromText(text, context, child)
+
+  def createExpression(text: String, context: PsiElement): Option[ScExpression] =
+    ScalaPsiElementFactory.safe(_.createExpressionFromText(text, context))
 
   @annotation.tailrec
   def resolveAliases(tpe: ScType): Option[ScType] =

--- a/src/test/scala/zio/inspections/InfallibleEffectRecoveryInspectionTest.scala
+++ b/src/test/scala/zio/inspections/InfallibleEffectRecoveryInspectionTest.scala
@@ -1,0 +1,123 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.mistakes.InfallibleEffectRecoveryInspection
+
+class InfallibleEffectRecoveryInspectionTest extends ZScalaInspectionTest[InfallibleEffectRecoveryInspection] {
+  private val faultyMethod = "orElse"
+
+  override protected val description = InfallibleEffectRecoveryInspection.description(faultyMethod)
+  private val hint                   = InfallibleEffectRecoveryInspection.hint(faultyMethod)
+
+  def testInlineHighlighting(): Unit =
+    z(s"${START}UIO(1).$faultyMethod(b)$END").assertHighlighted()
+
+  def testInlineReplacement(): Unit = {
+    val text   = z(s"UIO(1).$faultyMethod(b)")
+    val result = z("UIO(1)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValHighlighting(): Unit = z {
+    s"""val foo = UIO(1)
+       |${START}foo.$faultyMethod(b)$END""".stripMargin
+  }.assertHighlighted()
+
+  def testValReplacement(): Unit = {
+    val text = z {
+      s"""val foo = UIO(1)
+         |foo.$faultyMethod(b)""".stripMargin
+    }
+    val result = z {
+      """val foo = UIO(1)
+        |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefHighlighting(): Unit = z {
+    s"""def foo = UIO(1)
+       |${START}foo.$faultyMethod(b)$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefReplacement(): Unit = {
+    val text = z {
+      s"""def foo = UIO(1)
+         |foo.$faultyMethod(b)""".stripMargin
+    }
+    val result = z {
+      """def foo = UIO(1)
+        |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testInlineBlockHighlighting(): Unit =
+    z {
+      s"""${START}UIO(1).$faultyMethod {
+         |  val a = 1
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+  def testInlineBlockReplacement(): Unit = {
+    val text = z {
+      s"""UIO(1).$faultyMethod {
+         |  val a = 1
+         |  b
+         |}""".stripMargin
+    }
+    val result = z("UIO(1)")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValBlockHighlighting(): Unit =
+    z {
+      s"""val foo = UIO(1)
+         |${START}foo.$faultyMethod {
+         |  val a = 1
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+  def testValBlockReplacement(): Unit = {
+    val text = z {
+      s"""val foo = UIO(1)
+         |foo.$faultyMethod {
+         |  val a = 1
+         |  b
+         |}""".stripMargin
+    }
+    val result = z {
+      """val foo = UIO(1)
+        |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefBlockHighlighting(): Unit = z {
+    s"""def foo = UIO(1)
+       |${START}foo.$faultyMethod {
+       |  val a = 1
+       |  b
+       |}$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefBlockReplacement(): Unit = {
+    val text = z {
+      s"""def foo = UIO(1)
+         |foo.$faultyMethod {
+         |  val a = 1
+         |  b
+         |}""".stripMargin
+    }
+    val result = z {
+      """def foo = UIO(1)
+        |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testFallibleEffectNoHighlighting(): Unit =
+    z(s"${START}Task(1).$faultyMethod(b)$END").assertNotHighlighted()
+}

--- a/src/test/scala/zio/inspections/SimplifyErrorModificationInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyErrorModificationInspectionTest.scala
@@ -1,0 +1,67 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.simplifications.SimplifyErrorModificationInspection
+
+abstract class SimplifyErrorModificationInspectionTest(toReplace: String, toReplaceWith: String)
+    extends ZSimplifyInspectionTest[SimplifyErrorModificationInspection] {
+
+  private val methodToReplace     = s"$toReplace(_ => ???, f)"
+  private val methodToReplaceWith = s"$toReplaceWith(f)"
+
+  override protected val hint = s"Replace with .$toReplaceWith"
+
+  def testInlineHighlighting(): Unit =
+    z(s"${START}UIO(1).$methodToReplace$END").assertHighlighted()
+
+  def testInlineReplacement(): Unit = {
+    val text   = z(s"UIO(1).$methodToReplace")
+    val result = z(s"UIO(1).$methodToReplaceWith")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValHighlighting(): Unit = z {
+    s"""val foo = UIO(1)
+       |${START}foo.$methodToReplace$END""".stripMargin
+  }.assertHighlighted()
+
+  def testValReplacement(): Unit = {
+    val text = z {
+      s"""val foo = UIO(1)
+         |foo.$methodToReplace""".stripMargin
+    }
+    val result = z {
+      s"""val foo = UIO(1)
+         |foo.$methodToReplaceWith""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefHighlighting(): Unit = z {
+    s"""def foo = UIO(1)
+       |${START}foo.$methodToReplace$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefReplacement(): Unit = {
+    val text = z {
+      s"""def foo = UIO(1)
+         |foo.$methodToReplace""".stripMargin
+    }
+    val result = z {
+      s"""def foo = UIO(1)
+         |foo.$methodToReplaceWith""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testFallibleEffectNoHighlighting(): Unit =
+    z(s"${START}Task(1).$methodToReplace$END").assertNotHighlighted()
+
+}
+
+class SimplifyBimapErrorModificationInspectionTest   extends SimplifyErrorModificationInspectionTest("bimap", "map")
+class SimplifyTapBothErrorModificationInspectionTest extends SimplifyErrorModificationInspectionTest("tapBoth", "tap")
+class SimplifyFoldErrorModificationInspectionTest    extends SimplifyErrorModificationInspectionTest("fold", "map")
+class SimplifyFoldMErrorModificationInspectionTest   extends SimplifyErrorModificationInspectionTest("foldM", "flatMap")
+class SimplifyFoldTraceMErrorModificationInspectionTest
+    extends SimplifyErrorModificationInspectionTest("foldTraceM", "flatMap")

--- a/src/test/scala/zio/inspections/SimplifyErrorRecoveryInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyErrorRecoveryInspectionTest.scala
@@ -1,0 +1,70 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.simplifications.SimplifyErrorRecoveryInspection
+
+abstract class SimplifyErrorRecoveryInspectionTest(toReplace: String, toReplaceWith: String, requiredParams: Int = 0)
+    extends ZSimplifyInspectionTest[SimplifyErrorRecoveryInspection] {
+  private val params = if (requiredParams == 0) "" else List.fill(requiredParams)("???").mkString("(", ", ", ")")
+
+  private val methodToReplace     = s"$toReplace$params"
+  private val methodToReplaceWith = s"map($toReplaceWith)"
+
+  override protected val hint = s"Replace with .$methodToReplaceWith"
+
+  def testInlineHighlighting(): Unit =
+    z(s"${START}UIO(1).$methodToReplace$END").assertHighlighted()
+
+  def testInlineReplacement(): Unit = {
+    val text   = z(s"UIO(1).$methodToReplace")
+    val result = z(s"UIO(1).$methodToReplaceWith")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValHighlighting(): Unit = z {
+    s"""val foo = UIO(1)
+       |${START}foo.$methodToReplace$END""".stripMargin
+  }.assertHighlighted()
+
+  def testValReplacement(): Unit = {
+    val text = z {
+      s"""val foo = UIO(1)
+         |foo.$methodToReplace""".stripMargin
+    }
+    val result = z {
+      s"""val foo = UIO(1)
+         |foo.$methodToReplaceWith""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefHighlighting(): Unit = z {
+    s"""def foo = UIO(1)
+       |${START}foo.$methodToReplace$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefReplacement(): Unit = {
+    val text = z {
+      s"""def foo = UIO(1)
+         |foo.$methodToReplace""".stripMargin
+    }
+    val result = z {
+      s"""def foo = UIO(1)
+         |foo.$methodToReplaceWith""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testFallibleEffectNoHighlighting(): Unit =
+    z(s"${START}Task(1).$methodToReplace$END").assertNotHighlighted()
+
+}
+
+class SimplifyOptionErrorRecoveryInspectionTest extends SimplifyErrorRecoveryInspectionTest("option", "Some(_)")
+class SimplifyEitherErrorRecoveryInspectionTest extends SimplifyErrorRecoveryInspectionTest("either", "Right(_)")
+class SimplifyOrElseEitherErrorRecoveryInspectionTest
+    extends SimplifyErrorRecoveryInspectionTest("orElseEither", "Left(_)", 1)
+class SimplifyOrElseEitherAliasErrorRecoveryInspectionTest
+    extends SimplifyErrorRecoveryInspectionTest("<+>", "Left(_)", 1)
+class SimplifyRetryOrElseEitherErrorRecoveryInspectionTest
+    extends SimplifyErrorRecoveryInspectionTest("retryOrElseEither", "Right(_)", 2)

--- a/src/test/scala/zio/inspections/SimplifyErrorSeparationInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyErrorSeparationInspectionTest.scala
@@ -1,0 +1,95 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.simplifications.SimplifyErrorSeparationInspection
+
+abstract class SimplifyErrorSeparationInspectionTest(toReplace: String, toReplaceWith: String, isParN: Boolean = false)
+    extends ZSimplifyInspectionTest[SimplifyErrorSeparationInspection] {
+
+  private val nParamList: String = if (isParN) "(n)" else ""
+
+  private def methodToReplace(f: String)     = s"ZIO.$toReplace$nParamList(List(1, 2, 3))($f)"
+  private def methodToReplaceWith(f: String) = s"ZIO.$toReplaceWith$nParamList(List(1, 2, 3))($f)"
+
+  override protected val hint = s"Replace with ZIO.$toReplaceWith"
+
+  private def zdef(s: String): String = z {
+    s"""
+       |def foo(el: Any) = UIO(el)
+       |$s
+       |""".stripMargin
+  }
+
+  private def zval(s: String): String = z {
+    s"""
+       |val foo: Any => UIO[Any] = el => UIO(el)
+       |$s
+       |""".stripMargin
+  }
+
+  def testDefRefHighlighting(): Unit = zdef(s"$START${methodToReplace("foo")}$END").assertHighlighted()
+
+  def testDefRefReplacement(): Unit = {
+    val text   = zdef(s"${methodToReplace("foo")}")
+    val result = zdef(s"${methodToReplaceWith("foo")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefUnderscoreHighlighting(): Unit = zdef(s"$START${methodToReplace("foo(_)")}$END").assertHighlighted()
+
+  def testDefUnderscoreReplacement(): Unit = {
+    val text   = zdef(s"${methodToReplace("foo(_)")}")
+    val result = zdef(s"${methodToReplaceWith("foo(_)")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefLambdaHighlighting(): Unit = zdef(s"$START${methodToReplace("el => foo(el)")}$END").assertHighlighted()
+
+  def testDefLambdaReplacement(): Unit = {
+    val text   = zdef(s"${methodToReplace("el => foo(el)")}")
+    val result = zdef(s"${methodToReplaceWith("el => foo(el)")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValRefHighlighting(): Unit = zval(s"$START${methodToReplace("foo")}$END").assertHighlighted()
+
+  def testValRefReplacement(): Unit = {
+    val text   = zval(s"${methodToReplace("foo")}")
+    val result = zval(s"${methodToReplaceWith("foo")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValUnderscoreHighlighting(): Unit = zval(s"$START${methodToReplace("foo(_)")}$END").assertHighlighted()
+
+  def testValUnderscoreReplacement(): Unit = {
+    val text   = zval(s"${methodToReplace("foo(_)")}")
+    val result = zval(s"${methodToReplaceWith("foo(_)")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValLambdaHighlighting(): Unit = zval(s"$START${methodToReplace("el => foo(el)")}$END").assertHighlighted()
+
+  def testValLambdaReplacement(): Unit = {
+    val text   = zval(s"${methodToReplace("el => foo(el)")}")
+    val result = zval(s"${methodToReplaceWith("el => foo(el)")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testFallibleEffectNoHighlighting(): Unit =
+    z(s"$START${methodToReplace("Task(_)")}$END").assertNotHighlighted()
+
+}
+
+class SimplifyPartitionErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("partition", "foreach")
+class SimplifyPartitionParErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("partitionPar", "foreachPar")
+class SimplifyPartitionParNErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("partitionParN", "foreachParN", isParN = true)
+class SimplifyValidateErrorSeparationInspectionTest extends SimplifyErrorSeparationInspectionTest("validate", "foreach")
+class SimplifyValidateParErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("validatePar", "foreachPar")
+class SimplifyValidateFirstErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("validateFirst", "foreach")
+class SimplifyValidateFirstParErrorSeparationInspectionTest
+    extends SimplifyErrorSeparationInspectionTest("validateFirstPar", "foreachPar")


### PR DESCRIPTION
Closes zio#24.
Provides analisys for infallible effects and suggest fixes in accrodance with [ZIO docs](https://zio.dev/docs/can_fail)

Basically, there are two main parts here

1. `InfallibleEffectRecoveryInspection`
2. `SimplifyErrorModificationInspection`, `SimplifyErrorRecoveryInspection`, and `SimplifyErrorSeparationInspection`

The purpose of the first part is to detect any mtehods that require `CanFail` evidence without specific cases. Therefore, all it can do is to suggest deletion of these faulty operations.
The purpose of the second part is to handle special cases when simple deletion will change the type signature of the effect.
In case of methods like `ZIO.partition`, `ZIO.validate` or `ZIO.validateFirst`, it will still change the type signature, as well as the behavior. However, I think that some smarter fixes to these cases will be an overingeneered rather than a useful feature.

Everything in this PR is done only for `ZIO` types. I'll add similar things for `ZManaged` and other types if this PR will be accepted.