### PR TITLE
Integrated test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can run individual ZIO tests or the whole specs from IDEA:
 
 <img src="https://user-images.githubusercontent.com/601206/79748798-af318a00-8316-11ea-818d-5f266aa52ffe.png" />
 
-And view the results in the integrated runner (requires an [additional module in your project](https://github.com/zio/zio-test-intellij)):
+And view the results in the integrated runner:
 
 <img src="https://user-images.githubusercontent.com/601206/79748960-fb7cca00-8316-11ea-8e4a-e080de4bdf1c.png" />
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,11 @@
         <syntheticMemberInjector implementation="zio.intellij.synthetic.macros.MockableInjector"/>
     </extensions>
 
+    <applicationListeners>
+        <listener topic="com.intellij.openapi.project.ProjectManagerListener"
+                  class="zio.intellij.testsupport.runner.TestRunnerProjectListener"/>
+    </applicationListeners>
+
     <extensions defaultExtensionNs="com.intellij">
         <!-- simplifications -->
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyUnitInspection"
@@ -228,6 +233,8 @@
         <runLineMarkerContributor implementationClass="zio.intellij.testsupport.ZTestRunLineMarkerProvider"
                                   language="Scala" order="first"/>
         <testFramework implementation="zio.intellij.testsupport.ZTestFramework" order="first"/>
+
+        <applicationService serviceImplementation="zio.intellij.testsupport.runner.TestRunnerResolveService" />
     </extensions>
 
     <actions>

--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
@@ -1,5 +1,7 @@
 package zio.intellij.testsupport
 
+import java.net.URL
+
 import com.intellij.execution.configurations._
 import com.intellij.execution.impl.ConsoleViewImpl
 import com.intellij.execution.process.ProcessHandler
@@ -14,20 +16,22 @@ import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.{DefaultExecutionResult, ExecutionException, ExecutionResult, Executor}
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.util.InvalidDataException
 import com.intellij.psi.PsiClass
 import com.intellij.testIntegration.TestFramework
-import org.jetbrains.bsp.BspUtil
+import org.jetbrains.plugins.scala.ScalaVersion
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
-import org.jetbrains.plugins.scala.project.ModuleExt
+import org.jetbrains.plugins.scala.project.{LibraryExt, ModuleExt}
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestRunConfiguration.TestFrameworkRunnerInfo
 import org.jetbrains.plugins.scala.testingSupport.test._
 import org.jetbrains.plugins.scala.testingSupport.test.actions.ScalaRerunFailedTestsAction
 import org.jetbrains.plugins.scala.testingSupport.test.sbt._
 import org.jetbrains.plugins.scala.testingSupport.test.testdata.{ClassTestData, TestConfigurationData}
+import zio.intellij.testsupport.ZTestRunConfiguration.ZTestRunnerName
+import zio.intellij.testsupport.runner.TestRunnerResolveService
 import zio.intellij.utils._
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
@@ -47,13 +51,14 @@ class ZTestRunConfiguration(
 
   override val configurationProducer: ZTestRunConfigurationProducer = ZTestRunConfigurationProducer.instance
 
-  private val ZTestRunnerName = "zio.intellij.testsupport.ZTestRunner"
-
   override protected def runnerInfo: TestFrameworkRunnerInfo =
     TestFrameworkRunnerInfo(
-      if (Option(getModule).exists(hasTestRunner)) ZTestRunnerName
-      else fromTestConfiguration(testConfigurationData)
+      Option(getModule).flatMap { module =>
+        if (hasTestRunner(module)) Some(ZTestRunnerName)
+        else None
+      }.getOrElse(fromTestConfiguration(testConfigurationData))
     )
+
   override def getActionName: String = getName
 
   private def fromTestConfiguration(data: TestConfigurationData) =
@@ -63,20 +68,30 @@ class ZTestRunConfiguration(
         throw new InvalidDataException(s"Test configuration kind '${d.getKind}' is not supported.")
     }
 
-  private[testsupport] def shouldCreateTestConsole: Boolean =
+  private def resolveTestRunner(module: Module): Option[Seq[URL]] =
+    (module.zioVersion zip module.scalaVersion).headOption match {
+      case Some((zioVersion, scalaVersion)) =>
+        TestRunnerResolveService.instance.resolve(zioVersion, scalaVersion, false).toOption
+      case _ => None
+    }
+
+  private[testsupport] def usingIntegratedRunner: Boolean =
     runnerInfo.runnerClass == ZTestRunnerName
 
   private def hasTestRunner(module: Module): Boolean =
-    module.findLibrary(_.contains("zio-test-intellij")).isDefined
+    module.findLibrary(_.contains("zio-test-intellij")).isDefined ||
+      resolveTestRunner(module).isDefined
 
   override def getState(executor: Executor, env: ExecutionEnvironment): RunProfileState = {
     val module = getModule
     if (module == null) throw new ExecutionException("Module is not specified")
 
-    new ZioTestCommandLineState(env, module)
+    val testRunnerJars = resolveTestRunner(module)
+
+    new ZioTestCommandLineState(env, module, testRunnerJars)
   }
 
-  private class ZioTestCommandLineState(env: ExecutionEnvironment, module: Module)
+  private class ZioTestCommandLineState(env: ExecutionEnvironment, module: Module, testRunnerJars: Option[Seq[URL]])
       extends ScalaTestFrameworkCommandLineState(this, env, testConfigurationData, runnerInfo, sbtSupport)(
         project,
         module
@@ -84,7 +99,11 @@ class ZTestRunConfiguration(
 
     override def createJavaParameters(): JavaParameters = {
       val javaParameters = super.createJavaParameters()
-      // I'm sorry...
+
+      testRunnerJars.foreach { urls =>
+        javaParameters.getClassPath.addAll(urls.map(_.getFile).asJava)
+      }
+
       val params  = javaParameters.getProgramParametersList
       val newList = rebuildList(params.getParameters.asScala.toList)
       params.clearAll()
@@ -108,7 +127,7 @@ class ZTestRunConfiguration(
       val processHandler = startProcess()
 
       val consoleView: ConsoleView =
-        if (shouldCreateTestConsole) {
+        if (usingIntegratedRunner) {
           val consoleProperties = new SMTRunnerConsoleProperties(self, "ZIO Test", executor)
           SMTestRunnerConnectionUtil.createAndAttachConsole("ZIO Test", processHandler, consoleProperties)
         } else {
@@ -165,4 +184,7 @@ class ZTestRunConfiguration(
           override def testNameKey: Option[String] = Some("-t")
         }
     }
+}
+object ZTestRunConfiguration {
+  private[testsupport] val ZTestRunnerName = "zio.intellij.testsupport.ZTestRunner"
 }

--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfigurationProducer.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfigurationProducer.scala
@@ -1,7 +1,7 @@
 package zio.intellij.testsupport
 
 import com.intellij.execution.Location
-import com.intellij.execution.actions.ConfigurationFromContext
+import com.intellij.execution.actions.{ConfigurationContext, ConfigurationFromContext}
 import com.intellij.execution.configurations.{ConfigurationFactory, ConfigurationTypeUtil}
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerDownloader.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerDownloader.scala
@@ -1,0 +1,69 @@
+package zio.intellij.testsupport.runner
+
+import java.net.URL
+import java.nio.file.Path
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import org.apache.ivy.util.{AbstractMessageLogger, MessageLogger}
+import org.jetbrains.plugins.scala.{DependencyManager, DependencyManagerBase, ScalaVersion}
+import org.jetbrains.plugins.scala.DependencyManagerBase.{DependencyDescription, _}
+import zio.intellij.testsupport.runner.TestRunnerDownloader.DownloadProgressListener
+import zio.intellij.testsupport.runner.TestRunnerDownloader.DownloadResult.{DownloadFailure, DownloadSuccess}
+import zio.intellij.utils.Version
+
+import scala.util.control.NonFatal
+
+private[runner] class TestRunnerDownloader(progressListener: DownloadProgressListener) {
+
+  def download(version: Version)(implicit scalaVersion: ScalaVersion): Either[DownloadFailure, DownloadSuccess] =
+    try {
+      val resolver             = new DependencyResolver(progressListener)
+      val resolvedDependencies = resolver.resolve(dependencies(version.toString): _*)
+      val jars: Seq[Path]      = resolvedDependencies.map(_.file.toPath)
+      val urls                 = jars.map(_.toUri.toURL).toArray
+      Right(DownloadSuccess(version, scalaVersion, urls))
+    } catch {
+      case e: ProcessCanceledException => throw e
+      case NonFatal(e)                 => Left(DownloadFailure(version, scalaVersion, e))
+    }
+
+  private def dependencies(version: String)(implicit scalaVersion: ScalaVersion): Seq[DependencyDescription] =
+    List("dev.zio" %% s"zio-test-intellij" % version)
+
+  private class DependencyResolver(progressListener: DownloadProgressListener) extends DependencyManagerBase {
+    override protected val artifactBlackList: Set[String] = Set()
+    override protected val logLevel: Int                  = org.apache.ivy.util.Message.MSG_INFO
+    override def createLogger: MessageLogger = new AbstractMessageLogger {
+      override def doEndProgress(msg: String): Unit      = progressListener.progressUpdate(format(msg))
+      override def log(msg: String, level: Int): Unit    = progressListener.progressUpdate(format(msg))
+      override def rawlog(msg: String, level: Int): Unit = ()
+      override def doProgress(): Unit                    = progressListener.doProgress()
+    }
+
+    @inline
+    private def format(str: String): String =
+      firstLine(str).trim
+
+    private def firstLine(str: String): String = {
+      val strTrimmed = str
+      val newLineIdx = strTrimmed.indexOf("\n")
+      strTrimmed.substring(0, if (newLineIdx != -1) newLineIdx else strTrimmed.length)
+    }
+  }
+}
+object TestRunnerDownloader {
+  sealed trait DownloadResult
+  object DownloadResult {
+    final case class DownloadSuccess(version: Version, scalaVersion: ScalaVersion, jarUrls: Seq[URL])
+        extends DownloadResult
+    final case class DownloadFailure(version: Version, scalaVersion: ScalaVersion, cause: Throwable)
+        extends DownloadResult
+  }
+
+  trait DownloadProgressListener {
+    def progressUpdate(message: String): Unit
+    def doProgress(): Unit = ()
+  }
+
+  val NoopProgressListener: DownloadProgressListener = _ => {}
+}

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerNotifications.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerNotifications.scala
@@ -1,0 +1,76 @@
+package zio.intellij.testsupport.runner
+
+import com.intellij.notification._
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.util.ScalaCollectionsUtil
+
+import scala.collection.mutable
+import scala.ref.WeakReference
+
+private[runner] object TestRunnerNotifications {
+
+  private val notificationGroup =
+    new NotificationGroup("ZIO for IntelliJ", NotificationDisplayType.BALLOON, true)
+  private val notificationErrorGroup =
+    new NotificationGroup("ZIO for IntelliJ", NotificationDisplayType.STICKY_BALLOON, true)
+
+  // do not display notification with same content several times
+  private val messagesShown: mutable.Map[String, WeakReference[Notification]] = ScalaCollectionsUtil.newConcurrentMap
+
+  private def displayNotification(
+    message: String,
+    notificationType: NotificationType,
+    actions: Seq[NotificationAction] = Nil,
+    listener: Option[NotificationListener] = None
+  )(implicit project: Project): Unit = {
+    updateShownMessagesCache(message)
+    if (messagesShown.contains(message)) return
+
+    val notification: Notification =
+      if (notificationType == NotificationType.INFORMATION) {
+        notificationGroup.createNotification(message, notificationType)
+      } else {
+        notificationErrorGroup.createNotification(message, notificationType)
+      }
+    listener.foreach(notification.setListener)
+    actions.foreach(notification.addAction)
+    notification.notify(project)
+
+    messagesShown(message) = WeakReference(notification)
+    notification.whenExpired(() => messagesShown.remove(message))
+  }
+
+  // notification.getBalloon can be null right after notification creation
+  // so we can detect notification balloon close event only this way
+  private def updateShownMessagesCache(message: String): Unit =
+    messagesShown.get(message) match {
+      case Some(WeakReference(notification)) =>
+        val balloon = notification.getBalloon
+        if (balloon == null || balloon.isDisposed) {
+          messagesShown.remove(message)
+        }
+      case _ =>
+        messagesShown.remove(message)
+    }
+
+  def displayInfo(
+    message: String,
+    actions: Seq[NotificationAction] = Nil,
+    listener: Option[NotificationListener] = None
+  )(implicit project: Project = null): Unit =
+    displayNotification(message, NotificationType.INFORMATION, actions, listener)
+
+  def displayWarning(
+    message: String,
+    actions: Seq[NotificationAction] = Nil,
+    listener: Option[NotificationListener] = None
+  )(implicit project: Project = null): Unit =
+    displayNotification(message, NotificationType.WARNING, actions, listener)
+
+  def displayError(
+    message: String,
+    actions: Seq[NotificationAction] = Nil,
+    listener: Option[NotificationListener] = None
+  )(implicit project: Project = null): Unit =
+    displayNotification(message, NotificationType.ERROR, actions, listener)
+}

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectListener.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectListener.scala
@@ -1,0 +1,12 @@
+package zio.intellij.testsupport.runner
+
+import com.intellij.openapi.project.{Project, ProjectManagerListener}
+
+private[runner] final class TestRunnerProjectListener extends ProjectManagerListener {
+
+  override def projectOpened(project: Project): Unit =
+    new TestRunnerProjectNotification(project).init()
+
+  override def projectClosing(project: Project): Unit =
+    TestRunnerResolveService.instance.clearCaches()
+}

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
@@ -1,0 +1,78 @@
+package zio.intellij.testsupport.runner
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.{Notification, NotificationGroup, NotificationListener, NotificationType}
+import com.intellij.openapi.project.Project
+import javax.swing.event.HyperlinkEvent
+import org.jetbrains.annotations.NonNls
+import org.jetbrains.plugins.scala.project.{ModuleExt, ProjectExt}
+import zio.intellij.ZioIcon
+import zio.intellij.testsupport.runner.TestRunnerNotifications.displayInfo
+import zio.intellij.utils.{ModuleSyntax, TraverseAtHome}
+
+private[runner] final class TestRunnerProjectNotification(private val project: Project) {
+  def init(): Unit =
+    if (!findTestRunner(project)) {
+      createNotification.notify(project)
+    }
+
+  private def versions(project: Project) = {
+    val sourceModules = project.modulesWithScala.filter(_.isSourceModule).toList
+
+    sourceModules
+      // but we already have traverse at home...
+      // (converts a pair of options to option of pair)
+      .traverse(m => (m.zioVersion zip m.scalaVersion).headOption)
+      .flatMap(_.headOption)
+  }
+
+  private def findTestRunner(project: Project, downloadIfMissing: Boolean = false): Boolean =
+    versions(project).fold(false) {
+      case (version, scalaVersion) =>
+        TestRunnerResolveService.instance
+          .resolve(version, scalaVersion, downloadIfMissing)
+          .toOption
+          .isDefined
+    }
+
+  //noinspection HardCodedStringLiteral
+  private def href(ref: String, text: String): String = s"""<a href="$ref">$text</a>"""
+  @NonNls private val Nbsp                            = "&nbsp;"
+
+  private val listener: NotificationListener = (notification: Notification, link: HyperlinkEvent) => {
+    link.getDescription match {
+      case "download" =>
+        versions(project).foreach {
+          case (version, scalaVersion) =>
+            TestRunnerResolveService.instance
+              .resolveAsync(
+                version,
+                scalaVersion,
+                project,
+                onResolved = {
+                  case Right(_) => displayInfo("ZIO Test runner was downloaded successfully!")
+                  case _        => // relying on error reporting in resolve method
+                }
+              )
+        }
+        notification.expire()
+      case "learn_more" =>
+        BrowserUtil.open("https://plugins.jetbrains.com/plugin/13820-zio-for-intellij/zio-test-runner")
+      case _ =>
+    }
+  }
+
+  private def createNotification: Notification =
+    suggesterNotificationGroup
+      .createNotification(
+        "Enable the integrated ZIO Test runner",
+        href("download", "Download ZIO Test runner") + Nbsp * 6 +
+          href("learn_more", "Learn more..."),
+        NotificationType.INFORMATION,
+        listener
+      )
+      .setIcon(ZioIcon)
+
+  private val suggesterNotificationGroup: NotificationGroup =
+    NotificationGroup.balloonGroup("ZIO Test Runner")
+}

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerResolveService.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerResolveService.scala
@@ -1,0 +1,158 @@
+package zio.intellij.testsupport.runner
+
+import java.net.{URL, URLClassLoader}
+
+import com.intellij.openapi.components.{PersistentStateComponent, ServiceManager, State, Storage}
+import com.intellij.openapi.progress.{ProcessCanceledException, ProgressIndicator, Task}
+import com.intellij.openapi.project.Project
+import com.intellij.util.xmlb.XmlSerializerUtil
+import org.jetbrains.annotations.{Nls, NonNls}
+import org.jetbrains.plugins.scala.ScalaVersion
+import org.jetbrains.plugins.scala.extensions.invokeLater
+import org.jetbrains.plugins.scala.util.ScalaCollectionsUtil
+import zio.intellij.testsupport.ZTestRunConfiguration.ZTestRunnerName
+import zio.intellij.testsupport.runner.TestRunnerDownloader.DownloadResult.{DownloadFailure, DownloadSuccess}
+import zio.intellij.testsupport.runner.TestRunnerDownloader.{DownloadProgressListener, NoopProgressListener}
+import zio.intellij.testsupport.runner.TestRunnerResolveService.ResolveError.DownloadError
+import zio.intellij.testsupport.runner.TestRunnerResolveService._
+import zio.intellij.utils.Version
+
+import scala.beans.BeanProperty
+import scala.collection.mutable
+import scala.util._
+
+// Borrowed from ScalafmtDynamicServiceImpl and friends
+
+@State(name = "TestRunnerResolveService", storages = Array(new Storage("zio_testrunner_resolve_cache.xml")))
+private[runner] final class TestRunnerResolveService
+    extends PersistentStateComponent[TestRunnerResolveService.ServiceState] {
+
+  private val testRunnerVersions: mutable.Map[Version, ResolveStatus] = ScalaCollectionsUtil.newConcurrentMap
+
+  private val state: TestRunnerResolveService.ServiceState = new TestRunnerResolveService.ServiceState
+
+  override def getState: TestRunnerResolveService.ServiceState = state
+  override def loadState(state: TestRunnerResolveService.ServiceState): Unit =
+    XmlSerializerUtil.copyBean(state, this.state)
+
+  def resolve(
+    version: Version,
+    scalaVersion: ScalaVersion,
+    downloadIfMissing: Boolean,
+    resolveFast: Boolean = false,
+    progressListener: DownloadProgressListener = NoopProgressListener
+  ): ResolveResult = testRunnerVersions.get(version) match {
+    case Some(ResolveStatus.Resolved(jarPaths)) => Right(jarPaths)
+    case _ if resolveFast                       => Left(ResolveError.NotFound(version, scalaVersion))
+    case Some(ResolveStatus.DownloadInProgress) => Left(ResolveError.DownloadInProgress(version, scalaVersion))
+    case _ =>
+      if (state.resolvedVersions.containsKey(version.toString)) {
+        val jarUrls = state.resolvedVersions.get(version.toString).map(new URL(_))
+        resolveClassPath(version, scalaVersion, jarUrls) match {
+          case r @ Right(_)                 => r
+          case Left(_) if downloadIfMissing => downloadAndResolve(version, scalaVersion, progressListener)
+          case _                            => Left(ResolveError.NotFound(version, scalaVersion))
+        }
+      } else if (downloadIfMissing) downloadAndResolve(version, scalaVersion, progressListener)
+      else Left(ResolveError.NotFound(version, scalaVersion))
+  }
+
+  def resolveAsync(
+    version: Version,
+    scalaVersion: ScalaVersion,
+    project: Project,
+    onResolved: ResolveResult => Unit = _ => ()
+  ): Unit =
+    testRunnerVersions.get(version) match {
+      case Some(ResolveStatus.Resolved(fmt)) =>
+        invokeLater(onResolved(Right(fmt)))
+      case Some(ResolveStatus.DownloadInProgress) =>
+        invokeLater(onResolved(Left(ResolveError.DownloadInProgress(version, scalaVersion))))
+      case _ =>
+        @NonNls val title = s"Downloading the ZIO Test runner for ZIO $version"
+        val backgroundTask = new Task.Backgroundable(project, title, true) {
+          override def run(indicator: ProgressIndicator): Unit = {
+            indicator.setIndeterminate(true)
+            val progressListener = new ProgressIndicatorDownloadListener(indicator, title)
+            val result =
+              try {
+                resolve(version, scalaVersion, downloadIfMissing = true, progressListener = progressListener)
+              } catch {
+                case pce: ProcessCanceledException =>
+                  Left(DownloadError(version, scalaVersion, pce))
+              }
+            onResolved(result)
+          }
+        }
+
+        backgroundTask.setCancelText("Cancel downloading ZIO Test runner...")
+        backgroundTask.queue()
+    }
+
+  private def downloadAndResolve(
+    version: Version,
+    scalaVersion: ScalaVersion,
+    listener: DownloadProgressListener = NoopProgressListener
+  ): ResolveResult = {
+    val downloader = new TestRunnerDownloader(listener)
+    downloader.download(version)(scalaVersion).left.map(ResolveError.DownloadError.apply).flatMap {
+      case DownloadSuccess(v, scalaVersion, jarUrls) => resolveClassPath(v, scalaVersion, jarUrls)
+    }
+  }
+
+  private def resolveClassPath(version: Version, scalaVersion: ScalaVersion, jarUrls: Seq[URL]): ResolveResult = {
+    val urls: Array[URL] = jarUrls.toArray
+    Try(new URLClassLoader(urls, null).loadClass(ZTestRunnerName + "$")) match {
+      case Success(_) =>
+        state.resolvedVersions.put(version.toString, jarUrls.toArray.map(_.toString))
+        testRunnerVersions(version) = ResolveStatus.Resolved(jarUrls)
+        Right(jarUrls)
+      case Failure(e) =>
+        Left(ResolveError.UnknownError(version, scalaVersion, e))
+    }
+  }
+
+  private[runner] def clearCaches() = testRunnerVersions.clear()
+}
+object TestRunnerResolveService {
+  def instance: TestRunnerResolveService = ServiceManager.getService(classOf[TestRunnerResolveService])
+
+  type ResolveResult = Either[ResolveError, Seq[URL]]
+
+  sealed trait ResolveStatus
+  object ResolveStatus {
+    object DownloadInProgress                     extends ResolveStatus
+    final case class Resolved(jarPaths: Seq[URL]) extends ResolveStatus
+  }
+
+  sealed trait ResolveError
+  object ResolveError {
+    final case class NotFound(version: Version, scalaVersion: ScalaVersion)                        extends ResolveError
+    final case class DownloadInProgress(version: Version, scalaVersion: ScalaVersion)              extends ResolveError
+    final case class DownloadError(version: Version, scalaVersion: ScalaVersion, cause: Throwable) extends ResolveError
+    final case class UnknownError(version: Version, scalaVersion: ScalaVersion, cause: Throwable)  extends ResolveError
+
+    object DownloadError {
+      def apply(f: DownloadFailure): DownloadError = new DownloadError(f.version, f.scalaVersion, f.cause)
+    }
+  }
+
+  final class ServiceState() {
+    // ZIO version -> list of classpath jar URLs
+    @BeanProperty
+    var resolvedVersions: java.util.Map[String, Array[String]] = new java.util.TreeMap()
+  }
+
+  private class ProgressIndicatorDownloadListener(indicator: ProgressIndicator, @Nls prefix: String = "")
+      extends DownloadProgressListener {
+    override def progressUpdate(message: String): Unit = {
+      if (message.nonEmpty) {
+        //noinspection ReferencePassedToNls,ScalaExtractStringToBundle
+        indicator.setText(prefix + ": " + message)
+      }
+      indicator.checkCanceled()
+    }
+    override def doProgress(): Unit =
+      indicator.checkCanceled()
+  }
+}

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -6,8 +6,9 @@ import com.intellij.openapi.roots.OrderRootType
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.{JavaPsiFacade, PsiElement}
+import org.jetbrains.plugins.scala.ScalaVersion
 import org.jetbrains.plugins.scala.annotator.usageTracker.ScalaRefCountHolder
-import org.jetbrains.plugins.scala.extensions.PsiClassExt
+import org.jetbrains.plugins.scala.extensions.{executeOnPooledThread, PsiClassExt}
 import org.jetbrains.plugins.scala.lang.psi.api.base.ScFieldId
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.ScReferencePattern
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
@@ -19,7 +20,7 @@ import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
 import org.jetbrains.plugins.scala.lang.psi.types._
 import org.jetbrains.plugins.scala.lang.refactoring.ScTypePresentationExt
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
-import org.jetbrains.plugins.scala.project.{LibraryExt, ModuleExt}
+import org.jetbrains.plugins.scala.project.{LibraryExt, ModuleExt, ProjectExt, ScalaLanguageLevel}
 
 import scala.annotation.tailrec
 
@@ -142,6 +143,13 @@ package object utils {
       } yield version).headOption
 
     def zioVersion: Option[Version] = findLibrary(lib => lib.contains("/dev/zio/zio_") || lib.contains("/dev.zio/zio_"))
+
+    def scalaVersion =
+      for {
+        scalaSdk     <- module.scalaSdk
+        compiler     <- scalaSdk.compilerVersion
+        scalaVersion <- ScalaVersion.fromString(compiler)
+      } yield scalaVersion
   }
 
   implicit class TraverseAtHome[A](private val list: List[A]) extends AnyVal {


### PR DESCRIPTION
Fixes #51!

 - [x] Make it work asynchronously
 - [x] User prompt - notify when opening a project (if not found, scalafmt-style)
 - [x] Create the [Learn more...](https://plugins.jetbrains.com/plugin/13820-zio-for-intellij/zio-test-runner) page on the plugin page

This PR adds a background download from maven of a matching zio-test-intellij (by the project's scala and zio versions) module to enable the integrated test runner.
No need to add it to build.sbt anymore!

When opening the project containing ZIO for the first time, the following popup will be displayed:
![image](https://user-images.githubusercontent.com/601206/98386430-d3597c00-2058-11eb-8354-60c44f4cbf36.png)

Clicking on the **Download ZIO Test runner** link will download zio-test-runner from maven, matching the ZIO and Scala versions detected in the project.
Clicking **Learn more...** will open [this page](https://plugins.jetbrains.com/plugin/13820-zio-for-intellij/zio-test-runner) and the popup will remain open.

In case no matching version was found IntelliJ will default to the standard console runner.