### PR TITLE
Always wrapping for-comprehensions in parentheses when using .toLayer

### DIFF
--- a/src/test/scala/zio/inspections/SimplifyToLayerInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyToLayerInspectionTest.scala
@@ -22,6 +22,22 @@ sealed abstract class BaseToLayerInspectionTest(methodToReplace: String, methodT
     val result = z(base(s"serviceEffect.$methodToReplaceWith"))
     testQuickFixes(text, result, hint)
   }
+
+  def testForComprehension(): Unit = {
+    val text   = z(base(s"""
+                        |ZLayer.$methodToReplace {
+                        |  for {
+                        |    s <- serviceEffect
+                        |  } yield s
+                        |}
+                        |""".stripMargin))
+    val result = z(base(s"""
+                           |(for {
+                           |  s <- serviceEffect
+                           |} yield s).$methodToReplaceWith
+                           |""".stripMargin))
+    testQuickFixes(text, result, hint)
+  }
 }
 
 class SimplifyToLayerInspectionTest


### PR DESCRIPTION
Fixes #184 

I added a hack that always wraps for-comprehensions in parentheses. Seems to do the trick.
Do you think there's a better way of doing it? Can you think of other refactorings where this can apply? Maybe we can generalize `wrap` to support for-comprehensions.

@myazinn WDYT?