### PR TITLE
Add `NeedsEnv` support

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -206,6 +206,12 @@
                          shortName="SuggestTypeAliasInspection" level="INFORMATION"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.UnnecessaryEnvProvisionInspection"
+                         displayName="Effect doesn't require environment; there is no need to provide it"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="UnnecessaryEnvProvisionInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>

--- a/src/main/resources/inspectionDescriptions/UnnecessaryEnvProvisionInspection.html
+++ b/src/main/resources/inspectionDescriptions/UnnecessaryEnvProvisionInspection.html
@@ -1,0 +1,25 @@
+<html>
+Detects usages of methods that require `NeedsEnv` evidence on effects that do not require environment.
+For example
+<pre>
+    val urio: URIO[Int, Int] = ZIO.environment[Int]
+    val uio: UIO[Int]        = UIO(1)
+
+    urio.provide(1) // 1
+    uio.provide(1)  // 2
+
+</pre>
+Line 1 will not be highlighted since it is a valid code.
+<br/>
+Line 2 will be highlighted since uio doesn't require environment, which means `.provide` doesn't make sense and this
+code will not compile.
+<br/>
+Faulty operations can be discarded automatically,
+e.g.
+<pre>
+    uio.provide(???)          => uio
+    uio.provideSome(???)      => uio
+    uio.provideLayer(???)     => uio
+    uio.provideSomeLayer(???) => uio
+</pre>
+</html>

--- a/src/test/scala/zio/inspections/UnnecessaryEnvProvisionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/UnnecessaryEnvProvisionInspectionTest.scala
@@ -1,0 +1,139 @@
+package zio.inspections
+
+import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
+import zio.intellij.inspections.mistakes.UnnecessaryEnvProvisionInspection
+
+abstract class UnnecessaryEnvProvisionInspectionTest(fromEffect: String => String)
+    extends ZScalaInspectionTest[UnnecessaryEnvProvisionInspection] {
+  private val faultyMethod = "provideSomeLayer"
+
+  override protected val description = "Effect doesn't require environment; there is no need to provide it"
+  private val hint                   = UnnecessaryEnvProvisionInspection.hint(faultyMethod)
+
+  def testInlineHighlighting(): Unit =
+    z(s"$START${fromEffect("UIO(1)")}.$faultyMethod(???)$END").assertHighlighted()
+
+  def testInlineReplacement(): Unit = {
+    val text   = z(s"${fromEffect("UIO(1)")}.$faultyMethod(???)")
+    val result = z(fromEffect("UIO(1)"))
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValHighlighting(): Unit = z {
+    s"""val foo = ${fromEffect("UIO(1)")}
+       |${START}foo.$faultyMethod(???)$END""".stripMargin
+  }.assertHighlighted()
+
+  def testValReplacement(): Unit = {
+    val text = z {
+      s"""val foo = ${fromEffect("UIO(1)")}
+         |foo.$faultyMethod(???)""".stripMargin
+    }
+    val result = z {
+      s"""val foo = ${fromEffect("UIO(1)")}
+         |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefHighlighting(): Unit = z {
+    s"""def foo = ${fromEffect("UIO(1)")}
+       |${START}foo.$faultyMethod(???)$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefReplacement(): Unit = {
+    val text = z {
+      s"""def foo = ${fromEffect("UIO(1)")}
+         |foo.$faultyMethod(???)""".stripMargin
+    }
+    val result = z {
+      s"""def foo = ${fromEffect("UIO(1)")}
+         |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testInlineBlockHighlighting(): Unit =
+    z {
+      s"""$START${fromEffect("UIO(1)")}.$faultyMethod {
+         |  val a = 1
+         |  b
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+  def testInlineBlockReplacement(): Unit = {
+    val text = z {
+      s"""${fromEffect("UIO(1)")}.$faultyMethod {
+         |  val a = 1
+         |  ???
+         |}""".stripMargin
+    }
+    val result = z(s"${fromEffect("UIO(1)")}")
+    testQuickFixes(text, result, hint)
+  }
+
+  def testValBlockHighlighting(): Unit =
+    z {
+      s"""val foo = ${fromEffect("UIO(1)")}
+         |${START}foo.$faultyMethod {
+         |  val a = 1
+         |  ???
+         |}$END""".stripMargin
+    }.assertHighlighted()
+
+  def testValBlockReplacement(): Unit = {
+    val text = z {
+      s"""val foo = ${fromEffect("UIO(1)")}
+         |foo.$faultyMethod {
+         |  val a = 1
+         |  ???
+         |}""".stripMargin
+    }
+    val result = z {
+      s"""val foo = ${fromEffect("UIO(1)")}
+         |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testDefBlockHighlighting(): Unit = z {
+    s"""def foo = ${fromEffect("UIO(1)")}
+       |${START}foo.$faultyMethod {
+       |  val a = 1
+       |  ???
+       |}$END""".stripMargin
+  }.assertHighlighted()
+
+  def testDefBlockReplacement(): Unit = {
+    val text = z {
+      s"""def foo = ${fromEffect("UIO(1)")}
+         |foo.$faultyMethod {
+         |  val a = 1
+         |  ???
+         |}""".stripMargin
+    }
+    val result = z {
+      s"""def foo = ${fromEffect("UIO(1)")}
+         |foo""".stripMargin
+    }
+    testQuickFixes(text, result, hint)
+  }
+
+  def testSimpleProvideInlineHighlighting(): Unit =
+    z(s"$START${fromEffect("UIO(1)")}.provide(???)$END").assertHighlighted()
+
+  def testSimpleProvideInlineReplacement(): Unit = {
+    val text   = z(s"${fromEffect("UIO(1)")}.provide(???)")
+    val result = z(fromEffect("UIO(1)"))
+    testQuickFixes(text, result, UnnecessaryEnvProvisionInspection.hint("provide"))
+  }
+
+  def testFallibleEffectNoHighlighting(): Unit =
+    z(s"$START${fromEffect("ZIO.environment[Int]")}.$faultyMethod(???)$END").assertNotHighlighted()
+}
+
+class ZIOUnnecessaryEnvProvisionInspectionTest extends UnnecessaryEnvProvisionInspectionTest(identity)
+class ZManagedUnnecessaryEnvProvisionInspectionTest
+    extends UnnecessaryEnvProvisionInspectionTest(effect => s"ZManaged.fromEffect($effect)")
+class ZStreamUnnecessaryEnvProvisionInspectionTest
+    extends UnnecessaryEnvProvisionInspectionTest(effect => s"ZStream.fromEffect($effect)")


### PR DESCRIPTION
Almost the same as CanFail support (https://github.com/zio/zio-intellij/pull/178)
I decided to not try to unify it. It seemed to me that it would be more confusing than helpful. However, I still have my doubts about this and can correct it if necessary.