### PR TITLE
Implement #201: `*> ZIO.succeed` → `.as`

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -116,6 +116,16 @@
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyToLayerInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyZipRightToSucceedInspection"
+                         displayName="Simplify `*&gt; ZIO.succeed` to `.as`"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifyZipRightToSucceedInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedToZipLeftInspection"
+                         displayName="Simplify `ZIO.succeed &lt;*` to `.as`"
+                         groupPath="Scala,ZIO" groupName="Simplifications"
+                         shortName="SimplifySucceedToZipLeftInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
 
         <localInspection implementationClass="zio.intellij.inspections.mistakes.UnusedZIOExpressionsInspection"
                          displayName="Detects unused ZIO expressions that are mistakenly used like statements"

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -20,6 +20,9 @@ package object inspections {
 
   object zioMethods {
     val `.*>` : Qualified               = invocation("*>").from(zioLikePackages)
+    val `.zipRight`: Qualified          = invocation("zipRight").from(zioLikePackages)
+    val `.<*` : Qualified               = invocation("<*").from(zioLikePackages)
+    val `.zipLeft`: Qualified           = invocation("zipLeft").from(zioLikePackages)
     val `.as`: Qualified                = invocation("as").from(zioLikePackages)
     val `.map`: Qualified               = invocation("map").from(zioLikePackages)
     val `.flatMap`: Qualified           = invocation("flatMap").from(zioLikePackages)

--- a/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
@@ -1,7 +1,7 @@
 package zio.inspections
 
 import com.intellij.testFramework.EditorTestUtil.{SELECTION_END_TAG => END, SELECTION_START_TAG => START}
-import zio.intellij.inspections.simplifications.SimplifyZipRightInspection
+import zio.intellij.inspections.simplifications._
 
 abstract class ZipRightInspectionTest(s: String) extends ZSimplifyInspectionTest[SimplifyZipRightInspection] {
   override protected val hint = s"Replace with $s"
@@ -115,5 +115,31 @@ class SimplifyFlatmapWithZipRightOperatorTest extends ZipRightInspectionTest("*>
 
   def test_flatMap_not_discarding_should_not_highlight(): Unit =
     z(s"""ZIO.succeed("Benito Quinquela Martín").${START}flatMap(x => x)$END""").assertNotHighlighted()
+
+}
+
+class SimplifyZipRightToSucceedInspectionTest extends ZSimplifyInspectionTest[SimplifyZipRightToSucceedInspection] {
+  override protected val hint = s"Replace with .as"
+
+  def test_zipRight_to_succeed(): Unit = {
+    z(s"""${START}f("Fernando Fader").zipRight(ZIO.succeed("Carlos Alonso"))$END""").assertHighlighted()
+    val text   = z("""f("Fernando Fader").zipRight(ZIO.succeed("Carlos Alonso"))""")
+    val result = z("""f("Fernando Fader").as("Carlos Alonso")""")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_zipRight_infix_invocation_to_succeed(): Unit = {
+    z(s"""${START}f("Fernando Fader") zipRight ZIO.succeed("Carlos Alonso")$END""").assertHighlighted()
+    val text   = z("""f("Fernando Fader") zipRight ZIO.succeed("Carlos Alonso")""")
+    val result = z("""f("Fernando Fader").as("Carlos Alonso")""")
+    testQuickFixes(text, result, hint)
+  }
+
+  def test_zipRight_operator_to_succeed(): Unit = {
+    z(s"""${START}f("Fernando Fader") *> ZIO.succeed("Carlos Alonso")$END""").assertHighlighted()
+    val text   = z("""f("Fernando Fader") *> ZIO.succeed("Carlos Alonso")""")
+    val result = z("""f("Fernando Fader").as("Carlos Alonso")""")
+    testQuickFixes(text, result, hint)
+  }
 
 }


### PR DESCRIPTION
Assumptions & decisions:
1. This simplification is implemented as a part of existing Zip simplifications group, but inspections themselves had to be implemented as separate classes and registered in `plugin.xml` independently.
2. In the discussion with EpamLifeSciencesTeam we agreed to implement also simplification for `ZIO.succeed <*` as well.