### PR TITLE
Do not suggest `.unit` refactoring for chained expressions.

### DIFF
--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -7,7 +7,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.expr._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
 import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
-import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScTemplateDefinition}
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScObject, ScTemplateDefinition}
 import zio.intellij.utils.TypeCheckUtils._
 import zio.intellij.utils._
 import zio.intellij.utils.types._
@@ -210,7 +210,7 @@ package object inspections {
         case null                                                       => findOverloaded(ref)
         case t: ScTemplateDefinition if types.contains(t.qualifiedName) => Some(t.qualifiedName)
         case f: ScFunctionDefinition =>
-          Option(f.containingClass).map(_.qualifiedName).filter(types.contains)
+          Option(f.containingClass).collect { case o: ScObject => o.qualifiedName }.filter(types.contains)
         case _ => None
       }
   }

--- a/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyUnitInspectionTest.scala
@@ -38,4 +38,10 @@ class SimplifyUnitInspectionTest extends ZSimplifyInspectionTest[SimplifyUnitIns
 
   def test_does_not_highlight_unit_member(): Unit =
     z(s"""UIO(println("a")) $START*> UIO(println("b")).unit$END""").assertNotHighlighted()
+
+  def test_does_not_highlight_unit_member_on_chained_expressions(): Unit =
+    z(s"""val sideEffect = console.putStrLn("reproduce bug")
+         |(sideEffect $START*> sideEffect.forkDaemon.unit$END).exitCode
+         """.stripMargin).assertNotHighlighted()
+
 }


### PR DESCRIPTION
Fixes #211