### PR TITLE
Failed to run test due to invalid file path on Windows

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
@@ -1,7 +1,6 @@
 package zio.intellij.testsupport
 
 import java.net.URL
-
 import com.intellij.execution.actions.RunConfigurationProducer
 import com.intellij.execution.configurations._
 import com.intellij.execution.impl.ConsoleViewImpl
@@ -23,11 +22,13 @@ import zio.intellij.testsupport.ZTestRunConfiguration.ZTestRunnerName
 import zio.intellij.testsupport.runner.TestRunnerResolveService
 import zio.intellij.utils._
 
+import java.nio.file.Paths
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 final class ZTestRunConfiguration(project: Project, configurationFactory: ConfigurationFactory, name: String)
-    extends AbstractTestRunConfiguration(project, configurationFactory, name) { self =>
+    extends AbstractTestRunConfiguration(project, configurationFactory, name) {
+  self =>
 
   override val testFramework: ZTestFramework = TestFramework.EXTENSION_NAME.findExtension(classOf[ZTestFramework])
 
@@ -84,7 +85,7 @@ final class ZTestRunConfiguration(project: Project, configurationFactory: Config
       val javaParameters = super.createJavaParameters()
 
       testRunnerJars.foreach { urls =>
-        javaParameters.getClassPath.addAll(urls.map(_.getFile).asJava)
+        javaParameters.getClassPath.addAll(urls.map(u => Paths.get(u.toURI).toFile.toString).asJava)
       }
 
       val params  = javaParameters.getProgramParametersList
@@ -122,7 +123,9 @@ final class ZTestRunConfiguration(project: Project, configurationFactory: Config
       createExecutionResult(consoleView, processHandler)
     }
   }
+
 }
+
 object ZTestRunConfiguration {
   val ZTestRunnerName = "zio.intellij.testsupport.ZTestRunner"
 

--- a/src/test/scala/zio/intellij/testsupport/ZTestRunConfigurationTest.scala
+++ b/src/test/scala/zio/intellij/testsupport/ZTestRunConfigurationTest.scala
@@ -1,0 +1,46 @@
+package zio.intellij.testsupport
+
+import com.intellij.execution.configurations.JavaParameters
+
+import java.net.URL
+import java.nio.file.Paths
+import org.jetbrains.plugins.scala.base.ScalaLightCodeInsightFixtureTestAdapter
+import org.jetbrains.plugins.scala.util.Markers
+import org.junit.Assert.assertArrayEquals
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+class ZTestRunConfigurationTest extends ScalaLightCodeInsightFixtureTestAdapter with Markers {
+
+  self =>
+  def rebuildList(input: List[String]): List[String] = {
+    val mutableList: ListBuffer[String] = ListBuffer.empty[String]
+    input
+      .sliding(2, 2)
+      .toList
+      .collect {
+        case "-s" :: suite :: _       => mutableList.appendAll(Seq("-s", suite))
+        case "-testName" :: test :: _ => mutableList.appendAll(Seq("-t", test))
+      }
+    mutableList.toList
+  }
+
+  def testRunStateProvider(): Unit = {
+
+    val paths: Seq[URL] = Seq(
+      new URL("file:/C:/Users/taka/.ivy2/cache/dev.zio/zio-test-intellij_2.12/jars/zio-test-intellij_2.12-1.0.4.jar")
+    )
+
+    val javaParameters = new JavaParameters
+    javaParameters.getClassPath.addAll(paths.map(p => Paths.get(p.toURI).toFile.toString).asJava)
+
+    assertArrayEquals(
+      "must have same element",
+      javaParameters.getClassPath.getPathList.asScala.toArray: Array[Object],
+      Iterable(
+        """C:\Users\taka\.ivy2\cache\dev.zio\zio-test-intellij_2.12\jars\zio-test-intellij_2.12-1.0.4.jar"""
+      ).toArray: Array[Object]
+    )
+  }
+}


### PR DESCRIPTION
I was unable to run ZIO test due to the exception

` Illegal char <:> at index 2: \C:\tmp\.ivy2\cache\dev.zio\zio-test-intellij_2.13\jars\zio-test-intellij_2.13-1.0.4.jar`

on Windows 10

scalaVersion := "2.13.4"
zio-intellij := Version 2020.3.4.0
zioVersion = 1.0.4

This commit fix path handling on windows.