### PR TITLE
A hack to support Scala 3 artifact resolving

### DIFF
--- a/src/main/scala/zio/intellij/project/ZioProjectBuilder.scala
+++ b/src/main/scala/zio/intellij/project/ZioProjectBuilder.scala
@@ -23,6 +23,7 @@ import org.jetbrains.sbt.project.template.{SComboBox, SbtModuleBuilderUtil}
 import org.jetbrains.sbt.{Sbt, SbtBundle}
 import zio.intellij.{utils, ZioIcon}
 import zio.intellij.testsupport.runner.{TestRunnerDownloader, TestRunnerResolveService}
+import zio.intellij.utils.ScalaVersionHack
 
 import java.awt.FlowLayout
 import java.io.File
@@ -65,7 +66,7 @@ private[zio] class ZioProjectBuilder
       }
 
     def loadVersions = {
-      val url   = s"https://repo1.maven.org/maven2/dev/zio/zio_${scalaVersion.major}/"
+      val url   = s"https://repo1.maven.org/maven2/dev/zio/zio_${scalaVersion.versionStr}/"
       val lines = Versions.loadLinesFrom(url)
       val versionStrings = lines.fold(
         Function.const(hardcodedVersions),

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
@@ -12,7 +12,7 @@ import org.jetbrains.plugins.scala.project.{ModuleExt, ProjectExt}
 import zio.intellij.ZioIcon
 import zio.intellij.testsupport.runner.TestRunnerNotifications.{displayError, displayInfo}
 import zio.intellij.testsupport.runner.TestRunnerResolveService.{ResolveError, ResolveResult}
-import zio.intellij.utils.{ModuleSyntax, StringBuilderSyntax, Version}
+import zio.intellij.utils.{ModuleSyntax, ScalaVersionHack, StringBuilderSyntax, Version}
 
 import java.net.URLEncoder
 import javax.swing.event.HyperlinkEvent
@@ -109,15 +109,15 @@ private[runner] final class TestRunnerProjectNotification(private val project: P
     sb.appendLine("```")
     sb.appendLine(errors.map {
       case ResolveError.NotFound(version, scalaVersion) =>
-        s"Not found: zio-test-intellij_${scalaVersion.major}:$version"
+        s"Not found: zio-test-intellij_${scalaVersion.versionStr}:$version"
       case ResolveError.DownloadInProgress(version, scalaVersion) =>
-        s"Download in progress: zio-test-intellij_${scalaVersion.major}:$version"
+        s"Download in progress: zio-test-intellij_${scalaVersion.versionStr}:$version"
       case ResolveError.DownloadError(version, scalaVersion, cause) =>
-        s"""Download error: zio-test-intellij_${scalaVersion.major}:$version"
+        s"""Download error: zio-test-intellij_${scalaVersion.versionStr}:$version"
            |Cause:
            |${cause.toString}""".stripMargin
       case ResolveError.UnknownError(version, scalaVersion, cause) =>
-        s"""Unknown error: zio-test-intellij_${scalaVersion.major}:$version"
+        s"""Unknown error: zio-test-intellij_${scalaVersion.versionStr}:$version"
            |Cause:
            |${cause.toString}""".stripMargin
     }.mkString("---"))

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -157,6 +157,13 @@ package object utils {
       } yield scalaVersion
   }
 
+  implicit class ScalaVersionHack(private val version: ScalaVersion) extends AnyVal {
+    def versionStr = version.languageLevel match {
+      case ScalaLanguageLevel.Scala_3_0 => version.minor
+      case _                            => version.major
+    }
+  }
+
   implicit class TraverseAtHome[A](private val list: List[A]) extends AnyVal {
     def map2[A, B, C](oa: Option[A], ob: Option[B])(f: (A, B) => C): Option[C] =
       oa.flatMap(a => ob.map(b => f(a, b)))


### PR DESCRIPTION
Scala 3 artifacts are currently published e.g. `zio_test_intellij_3.0.0-M3:1.0.4`, so using just the `major` prefix no longer works.

This adds a hack that if the current version is Scala 3, then using the full version number...