### PR TITLE
Prevent test runner prompt in projects with unsupported ZIO versions

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
@@ -28,9 +28,12 @@ private[runner] final class TestRunnerProjectNotification(private val project: P
   private def versions(project: Project) = {
     val sourceModules = project.modulesWithScala.filter(_.isSourceModule).toList
 
-    sourceModules
-      .flatMap(m => m.zioVersion zip m.scalaVersion)
-      .distinct
+    sourceModules.flatMap { m =>
+      // First ZIO Test runner release: RC18-2
+      // Do not try to download test runner for ZIO versions without runner release
+      val zioVersion = m.zioVersion.filter(v => Version.ZIO.`RC18-2` <= v && v <= Version.ZIO.`latest-ish`)
+      zioVersion zip m.scalaVersion
+    }.distinct
   }
 
   private def shouldSuggestTestRunner(project: Project, downloadIfMissing: Boolean = false): Boolean =

--- a/src/main/scala/zio/intellij/utils/Version.scala
+++ b/src/main/scala/zio/intellij/utils/Version.scala
@@ -104,9 +104,12 @@ object Version {
 
   object ZIO {
     val RC18: Version     = Version.parseUnsafe("1.0.0-RC18")
+    val `RC18-2`: Version = Version.parseUnsafe("1.0.0-RC18-2")
     val RC19: Version     = Version.parseUnsafe("1.0.0-RC19")
     val RC21: Version     = Version.parseUnsafe("1.0.0-RC21")
     val `RC21-2`: Version = Version.parseUnsafe("1.0.0-RC21-2")
     val `1.0.0`: Version  = Version.parseUnsafe("1.0.0")
+
+    val `latest-ish`: Version = Version.parseUnsafe("1.0.6")
   }
 }

--- a/src/test/scala/zio/intellij/utils/VersionTestUtils.scala
+++ b/src/test/scala/zio/intellij/utils/VersionTestUtils.scala
@@ -42,7 +42,8 @@ object VersionTestUtils {
       |<version>1.0.4</version>
       |<version>1.0.4-1</version>
       |<version>1.0.4-2</version>
-      |<version>1.0.5</version>""".stripMargin
+      |<version>1.0.5</version>
+      |<version>1.0.6</version>""".stripMargin
       .replace("<version>", "")
       .replace("</version>", "")
       .split(System.lineSeparator())


### PR DESCRIPTION
Download runner if ZIO version >= 1.0.0-RC18-2 and <= latest version with published test runner

Hopefully closes #259 🙂

Not sure about this "latest published version" thing though... We either manually update the latest version in Version.scala on each test runner release, or get a download error if the test runner was not released fast enough