### PR TITLE
Downloading the test runner correctly on Scala 3 projects

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.12.1")
+addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.12.4")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"    % "2.4.2")

--- a/src/main/scala/zio/intellij/project/ZioProjectBuilder.scala
+++ b/src/main/scala/zio/intellij/project/ZioProjectBuilder.scala
@@ -15,13 +15,13 @@ import org.jetbrains.plugins.scala.LatestScalaVersions.Scala_2_13
 import org.jetbrains.plugins.scala.extensions.JComponentExt.ActionListenersOwner
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.project.{ScalaLanguageLevel, Version, Versions}
-import org.jetbrains.plugins.scala.{ScalaBundle, ScalaVersion, extensions}
+import org.jetbrains.plugins.scala.{extensions, ScalaBundle, ScalaVersion}
 import org.jetbrains.sbt.project.SbtProjectSystem
 import org.jetbrains.sbt.project.settings.SbtProjectSettings
 import org.jetbrains.sbt.project.template.SbtModuleBuilderUtil.{doSetupModule, getOrCreateContentRootDir}
 import org.jetbrains.sbt.project.template.{SComboBox, SbtModuleBuilderUtil}
 import org.jetbrains.sbt.{Sbt, SbtBundle}
-import zio.intellij.{ZioIcon, utils}
+import zio.intellij.{utils, ZioIcon}
 import zio.intellij.testsupport.runner.{TestRunnerDownloader, TestRunnerResolveService}
 import zio.intellij.utils.ScalaVersionHack
 import zio.intellij.utils.Version.ZIO

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
@@ -28,11 +28,11 @@ abstract class ModulePatternAccessibleBase extends SyntheticMembersInjector {
     protected val typeArgsForAccessors: Seq[ScTypeParam]
 
     final def apply(sco: ScObject): Seq[String] = {
-      val serviceName  =
+      val serviceName =
         if (sco.typeDefinitions.exists(_.name == "Service")) s"${sco.qualifiedName}.Service"
         else sco.qualifiedName
-      val aliasName   = s"${sco.qualifiedName}.${sco.name}"
-      val methods     = (serviceTrait.allMethods ++ serviceTrait.allVals).toSeq
+      val aliasName = s"${sco.qualifiedName}.${sco.name}"
+      val methods   = (serviceTrait.allMethods ++ serviceTrait.allVals).toSeq
 
       def withTypeParams(srv: String): String =
         s"$srv${typeParametersApplication(typeArgsForService)}"
@@ -104,7 +104,7 @@ abstract class ModulePatternAccessibleBase extends SyntheticMembersInjector {
       case tr: ScTrait if tr.name == "Service" => tr
     }.orElse(sco.fakeCompanionClassOrCompanionClass match {
       case typeDef: ScTrait => Some(typeDef)
-      case _ => None
+      case _                => None
     })
 
   override def injectMembers(source: ScTypeDefinition): Seq[String] =

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -161,9 +161,12 @@ package object utils {
 
   implicit class ScalaVersionHack(private val version: ScalaVersion) extends AnyVal {
     def versionStr = version.languageLevel match {
-      case ScalaLanguageLevel.Scala_3_0 => version.minor
-      case _                            => version.major
+      case ScalaLanguageLevel.Scala_3_0 if version.isPrerelease => version.minor
+      case ScalaLanguageLevel.Scala_3_0                         => "3" // sigh :(
+      case _                                                    => version.major
     }
+
+    def isPrerelease = version.minorSuffix.contains("-")
   }
 
   implicit class TraverseAtHome[A](private val list: List[A]) extends AnyVal {


### PR DESCRIPTION
Scala 3 with sbt 1.5 changes the way dependencies are resolved to keep binary compatibility. For Scala 3.0.0, resolving e.g. `"dev.zio" %% "zio-test-intellij % version` will try to resolve `zio_test_intellij_3` (instead of `_3.0.0` as it used to do before).

For more information: https://www.scala-lang.org/blog/2021/04/08/scala-3-in-sbt.html