### PR TITLE
Detecting incorrect usage of 'class' instead of 'object in ZIO specs

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,82 +45,98 @@
                          groupName="Simplifications"
                          shortName="SimplifyUnitInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyIgnoreInspection"
                          displayName="Simplify recovering with Unit to .ignore" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyIgnoreInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyMapInspection"
                          displayName="Simplify discarding effect result to .as/.orElseFail" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyMapInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyBimapInspection"
                          displayName="Simplify mapping result and error effects to .bimap" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyBimapInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyWhenInspection"
                          displayName="Simplify condition to .when" groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyWhenInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyUnlessInspection"
                          displayName="Simplify condition to .unless" groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyUnlessInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedEitherInspection"
                          displayName="Simplify Either values to .left/.right" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifySucceedEitherInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedOptionInspection"
                          displayName="Simplify optional values to .none/.some" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifySucceedOptionInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyCollectAllInspection"
                          displayName="Simplify collection of effects obtained by mapping each element of some Iterable to foreach"
                          groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyCollectAllInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyTapInspection"
                          displayName="Simplify various call chains with .tap"
                          groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyTapInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyExitCodeInspection"
                          displayName="Simplify producing an exit code"
                          groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyExitCodeInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySleepInspection"
                          displayName="Simplify ZIO.sleep to .delay" groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifySleepInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyServiceInspection"
                          displayName="Simplify ZIO.access(_.get) with ZIO.service"
                          groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyServiceInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyChainToForInspection"
                          displayName="Convert `*>` chain to for-comprehension and vice versa"
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyChainToForInspection" level="INFORMATION"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyToLayerInspection"
                          displayName="Simplify ZLayer.fromEffect(Many) to .toLayer(Many)"
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyToLayerInspection" level="WEAK WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyZipRightToSucceedInspection"
                          displayName="Simplify `*&gt; ZIO.succeed` to `.as`"
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyZipRightToSucceedInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedToZipLeftInspection"
                          displayName="Simplify `ZIO.succeed &lt;*` to `.as`"
                          groupPath="Scala,ZIO" groupName="Simplifications"
@@ -180,11 +196,13 @@
                          groupPath="Scala,ZIO" groupName="Simplifications"
                          shortName="SimplifyFailInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyFlattenInspection"
                          displayName="Replace .map and .flatten with .flatMap" groupPath="Scala,ZIO"
                          groupName="Simplifications"
                          shortName="SimplifyFlattenInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifyOrElseInspection"
                          displayName="Simplify .orElse(ZIO.fail) to .orElseFail"
                          groupPath="Scala,ZIO" groupName="Simplifications"
@@ -231,6 +249,12 @@
                          displayName="Effect doesn't require environment; there is no need to provide it"
                          groupPath="Scala,ZIO" groupName="Inspections"
                          shortName="UnnecessaryEnvProvisionInspection" level="ERROR"
+                         enabledByDefault="true" language="Scala"/>
+
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.IncorrectTestClassInspection"
+                         displayName="Detects incorrect use of 'class' instead of 'object' for ZIO Tests specs"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="IncorrectTestClassInspection" level="ERROR"
                          enabledByDefault="true" language="Scala"/>
 
         <intentionAction>

--- a/src/main/scala/zio/intellij/inspections/mistakes/IncorrectTestClassInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/IncorrectTestClassInspection.scala
@@ -1,0 +1,62 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection.{InspectionManager, LocalQuickFix, ProblemDescriptor, ProblemHighlightType}
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, AbstractRegisteredInspection}
+import org.jetbrains.plugins.scala.lang.lexer.ScalaTokenType.ObjectKeyword
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScClass
+import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory
+import org.jetbrains.plugins.scala.lang.psi.{ElementScope, ScalaPsiUtil}
+import zio.intellij.inspections.mistakes.IncorrectTestClassInspection.ReplaceTargetToken
+import zio.intellij.testsupport.ZSpecFQN
+
+class IncorrectTestClassInspection extends AbstractRegisteredInspection {
+
+  override protected def problemDescriptor(
+    element: PsiElement,
+    maybeQuickFix: Option[LocalQuickFix],
+    descriptionTemplate: String,
+    highlightType: ProblemHighlightType
+  )(implicit manager: InspectionManager, isOnTheFly: Boolean): Option[ProblemDescriptor] =
+    element match {
+      case c: ScClass if extendsZSpec(c) =>
+        Some(
+          manager.createProblemDescriptor(
+            c.targetToken,
+            "ZIO Spec must be an 'object' instead of 'class'.",
+            isOnTheFly,
+            Array[LocalQuickFix](new ReplaceTargetToken(c)),
+            ProblemHighlightType.GENERIC_ERROR
+          )
+        )
+      case _ => None
+    }
+
+  private def extendsZSpec(definition: ScClass) = {
+    val elementScope = ElementScope(definition.getProject)
+
+    val cachedClass = elementScope.getCachedClass(ZSpecFQN)
+    cachedClass.exists(ScalaPsiUtil.isInheritorDeep(definition, _))
+  }
+}
+object IncorrectTestClassInspection {
+  final class ReplaceTargetToken(param: ScClass)
+      extends AbstractFixOnPsiElement("Replace 'class' with 'object'", param) {
+
+    override protected def doApplyFix(c: ScClass)(implicit project: Project): Unit = {
+      // borrowed from ConvertToObjectFix
+      val classKeywordTextRange = c.targetToken.getTextRange
+
+      val objectText = c.getText.patch(
+        classKeywordTextRange.getStartOffset - c.getTextRange.getStartOffset,
+        ObjectKeyword.text,
+        classKeywordTextRange.getLength
+      )
+
+      val objectElement = ScalaPsiElementFactory.createObjectWithContext(objectText, c.getContext, c)
+      c.replace(objectElement)
+    }
+  }
+
+}

--- a/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
@@ -2,9 +2,10 @@ package zio.intellij.testsupport
 
 import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.codeInspection.collections.isOfClassFrom
-import org.jetbrains.plugins.scala.extensions.{PsiElementExt, ResolvesTo}
-import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScInfixExpr, ScMethodCall, ScPostfixExpr, ScReferenceExpression}
+import org.jetbrains.plugins.scala.extensions.{ObjectExt, PsiElementExt, ResolvesTo}
+import org.jetbrains.plugins.scala.lang.psi.api.expr._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.ScClassImpl
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
@@ -14,8 +15,8 @@ import zio.intellij.utils.TypeCheckUtils.zioTestPackage
 import scala.annotation.tailrec
 
 final class ZTestFramework extends AbstractTestFramework {
-  override def getMarkerClassFQName: String = ZSuitePaths.head
-  override def getDefaultSuperClass: String = ZSuitePaths.head
+  override def getMarkerClassFQName: String = ZSpecFQN
+  override def getDefaultSuperClass: String = ZSpecFQN
   override def testFileTemplateName: String = "ZIO Test Suite"
   override def getName: String              = "ZIO Test"
 
@@ -27,7 +28,11 @@ final class ZTestFramework extends AbstractTestFramework {
       case _                         => false
     }
 
-  override def baseSuitePaths: Seq[String] = ZSuitePaths
+  override protected def isTestClass(definition: ScTemplateDefinition): Boolean =
+    if (!definition.is[ScObject]) false
+    else super.isTestClass(definition)
+
+  override def baseSuitePaths: Seq[String] = List(ZSpecFQN)
 
   private def resolvesToTestMethod(sc: ScReferenceExpression): Boolean =
     sc match {

--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfigurationProducer.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfigurationProducer.scala
@@ -17,7 +17,7 @@ final class ZTestRunConfigurationProducer extends AbstractTestConfigurationProdu
     configurationType.confFactory
   }
 
-  override protected def suitePaths: List[String] = ZSuitePaths
+  override protected def suitePaths: List[String] = List(ZSpecFQN)
 
   override def shouldReplace(self: ConfigurationFromContext, other: ConfigurationFromContext): Boolean =
     other.isProducedBy(classOf[ScalaApplicationConfigurationProducer])

--- a/src/main/scala/zio/intellij/testsupport/package.scala
+++ b/src/main/scala/zio/intellij/testsupport/package.scala
@@ -16,7 +16,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinitio
 import scala.jdk.CollectionConverters._
 
 package object testsupport {
-  val ZSuitePaths = List("zio.test.RunnableSpec")
+  val ZSpecFQN = "zio.test.RunnableSpec"
 
   def parentTypeDefinition(e: PsiElement): Option[ScTypeDefinition] =
     parentOfType(e, classOf[ScTypeDefinition], strict = false)


### PR DESCRIPTION
Fixes #265 

Finally fixed this particular landmine :)

![image](https://user-images.githubusercontent.com/601206/121262195-66db7f80-c8bc-11eb-81cc-2dcd9488536e.png)

![image](https://user-images.githubusercontent.com/601206/121262225-70fd7e00-c8bc-11eb-9ce6-feb22d9db7f4.png)

![image](https://user-images.githubusercontent.com/601206/121262242-78bd2280-c8bc-11eb-9010-1eacdf40d64a.png)
