### PR TITLE
Update supported Intellij versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The plugin is now available on the [JetBrains Plugin Marketplace](https://plugin
 
 <img src="https://user-images.githubusercontent.com/601206/79748708-89a48080-8316-11ea-95a3-3542dab04684.png" />
 
-**Supported versions**: IntelliJ IDEA 2019.3, 2020.x, 2021.x (Community edition or better)
+**Supported versions**: IntelliJ IDEA 2021.x (Community edition or better)
 
 ### Features
 


### PR DESCRIPTION
I believe 2020.3 support was dropped in 69ea426 (part of the [v2021.1.6](https://github.com/zio/zio-intellij/releases/tag/v2021.1.6) release.) This PR updates the readme to reflect reality.

This is corroborated by the [version compatibility chart](https://plugins.jetbrains.com/plugin/13820-zio-for-intellij/versions/stable) on the JetBrains plugin page (screenshot below), and I can additionally confirm that I can not update to newer versions in my own IntelliJ installation (IntelliJ 2020.3).

<img width="976" alt="image" src="https://user-images.githubusercontent.com/5134584/121265067-324cd100-c886-11eb-9d3f-f3d48fe86519.png">
