### PR TITLE
Restricting the catchAll-tap refactoring to only when using ZIO.fail

### DIFF
--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyTapInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyTapInspection.scala
@@ -94,8 +94,10 @@ sealed abstract class BaseRefactoringType(invocation: Qualified, replaceWith: St
           // .flatMap*(a => expr(e).as(a))
           case ref `.as` ScReferenceExpression(a) if a == param => Some(replacement(qual, param, ref))
           // .catchAll(e => expr(e) *> ZIO.fail(e))
-          case ScInfixExpr(ref, _, `ZIO.fail`(_, _)) => Some(replacement(qual, param, ref))
-          case _                                     => None
+          case ScInfixExpr(ref, _, `ZIO.fail`(_, ScReferenceExpression(a))) if a == param =>
+            Some(replacement(qual, param, ref))
+          // all other cases, e.g. calling ZIO.fail(someMethod(args)) do not match
+          case _ => None
         }
       case _ => None
     }

--- a/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyTapInspectionTest.scala
@@ -111,6 +111,10 @@ class SimplifyTapErrorInspectionTest extends BaseSimplifyTapInspectionTest(".tap
     testQuickFixes(text, result, hint)
   }
 
+  def test_catchAll_zipRight_ZIO_fail_with_anything_other_than_catchAll_parameter(): Unit = {
+    z(s"ZIO.unit.${START}catchAll(ex => logError(ex) *> ZIO.fail(convertLeft(ex)))$END").assertNotHighlighted()
+  }
+
   def test_flatMapError_reduce_func_no_params(): Unit = {
     z(s"ZIO.unit.${START}flatMapError(a => f(a).as(a))$END").assertHighlighted()
     val text   = z(s"ZIO.unit.flatMapError(a => f(a).as(a))")


### PR DESCRIPTION
Fixes #274

This restricts the refactoring to only consider the simplest cases, e.g.

`effect.catchAll(e => logError(e) *> ZIO.fail(e))`, i.e. where `ZIO.fail` is used with the catchAll parameter directly. All other cases are more complex, therefore not considered.