### PR TITLE
Create Test dialog for ZIO Test

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -286,6 +286,8 @@
 
         <projectService serviceImplementation="zio.intellij.testsupport.runner.TestRunnerResolveService" />
 
+        <testCreator language="Scala" implementationClass="zio.intellij.testsupport.ZTestCreator" order="first" />
+
         <!-- Project template -->
         <projectTemplatesFactory implementation="zio.intellij.project.ZioProjectTemplateFactory" order="last"/>
 

--- a/src/main/scala/zio/intellij/testsupport/ZTestCreator.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestCreator.scala
@@ -1,0 +1,66 @@
+package zio.intellij.testsupport
+
+import com.intellij.codeInsight.TestFrameworks
+import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.psi.{PsiClass, PsiFile, PsiPackage}
+import com.intellij.testIntegration.createTest.{CreateTestAction, CreateTestDialog}
+import com.intellij.util.IncorrectOperationException
+import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScClass, ScObject, ScTypeDefinition}
+import org.jetbrains.plugins.scala.project.ProjectExt
+import org.jetbrains.plugins.scala.testingSupport.ScalaTestCreator
+import zio.intellij.ZioIcon
+import zio.intellij.utils.ModuleSyntax
+
+import javax.swing.Icon
+
+// TODO this class is a hack on top of ScalaTestCreator *just* to have the default suffix for tests be `Specs`.
+// Otherwise, this class is a copy of ScalaTestCreator, with some added presentation.
+// Unfortunately, there doesn't seem to be a way to *disable* the built-in ScalaTestCreator item, so the prompt
+// to create a new test (Cmd/Ctrl+Shift+T) will always have two items. At least ours is prettier :)
+final class ZTestCreator extends ScalaTestCreator with ItemPresentation {
+
+  override def createTest(project: Project, editor: Editor, file: PsiFile): Unit = {
+    import ZTestCreator._
+    try {
+      val action = new CreateTestAction {
+        override protected def createTestDialog(
+          project: Project,
+          srcModule: Module,
+          srcClass: PsiClass,
+          srcPackage: PsiPackage
+        ): CreateTestDialog =
+          new CreateTestDialog(project, getText, srcClass, srcPackage, srcModule) {
+            override def suggestTestClassName(targetClass: PsiClass): String = targetClass match {
+              case obj: ScTypeDefinition =>
+                obj.name.stripSuffix("$") + "Spec" // Y U NOT LET ME CONFIGURE THIS JETBRAIN!
+              case _ => super.suggestTestClassName(targetClass)
+            }
+          }
+      }
+      val element = findElement(file, editor.getCaretModel.getOffset)
+      if (CreateTestAction.isAvailableForElement(element)) action.invoke(project, editor, element)
+    } catch {
+      case e: IncorrectOperationException => LOG.warn(e)
+    }
+  }
+
+  override def isAvailable(project: Project, editor: Editor, file: PsiFile): Boolean =
+    project.modules.exists(_.hasZio) && super.isAvailable(project, editor, file)
+
+  override def getPresentableText: String = "Create New ZIO Spec..."
+
+  override def getIcon(unused: Boolean): Icon = ZioIcon
+}
+
+object ZTestCreator {
+  private val LOG = Logger.getInstance("zio.intellij.testsupport.ZTestCreator")
+  private def findElement(file: PsiFile, offset: Int) = {
+    var element = file.findElementAt(offset)
+    if (element == null && offset == file.getTextLength) element = file.findElementAt(offset - 1)
+    element
+  }
+}

--- a/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
@@ -9,16 +9,19 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef._
 import org.jetbrains.plugins.scala.lang.psi.impl.toplevel.typedef.ScClassImpl
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
 import org.jetbrains.plugins.scala.testingSupport.test.AbstractTestFramework
+import zio.intellij.ZioIcon
 import zio.intellij.testsupport.ZTestFramework.expandsToTestMethod
 import zio.intellij.utils.TypeCheckUtils.zioTestPackage
 
+import javax.swing.Icon
 import scala.annotation.tailrec
 
 final class ZTestFramework extends AbstractTestFramework {
   override def getMarkerClassFQName: String = ZSpecFQN
-  override def getDefaultSuperClass: String = ZSpecFQN
+  override def getDefaultSuperClass: String = DefaultRunnableSpec
   override def testFileTemplateName: String = "ZIO Test Suite"
   override def getName: String              = "ZIO Test"
+  override def getIcon: Icon                = ZioIcon
 
   override def isTestMethod(element: PsiElement): Boolean = isTestMethod(element, checkAbstract = false)
 
@@ -32,7 +35,7 @@ final class ZTestFramework extends AbstractTestFramework {
     if (!definition.is[ScObject]) false
     else super.isTestClass(definition)
 
-  override def baseSuitePaths: Seq[String] = List(ZSpecFQN)
+  override def baseSuitePaths: Seq[String] = List(DefaultRunnableSpec, DefaultMutableRunnableSpec)
 
   private def resolvesToTestMethod(sc: ScReferenceExpression): Boolean =
     sc match {

--- a/src/main/scala/zio/intellij/testsupport/package.scala
+++ b/src/main/scala/zio/intellij/testsupport/package.scala
@@ -16,8 +16,8 @@ import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScTypeDefinitio
 import scala.jdk.CollectionConverters._
 
 package object testsupport {
-  val ZSpecFQN = "zio.test.RunnableSpec"
-  val DefaultRunnableSpec = "zio.test.DefaultRunnableSpec"
+  val ZSpecFQN                   = "zio.test.RunnableSpec"
+  val DefaultRunnableSpec        = "zio.test.DefaultRunnableSpec"
   val DefaultMutableRunnableSpec = "zio.test.DefaultMutableRunnableSpec"
 
   def parentTypeDefinition(e: PsiElement): Option[ScTypeDefinition] =

--- a/src/main/scala/zio/intellij/testsupport/package.scala
+++ b/src/main/scala/zio/intellij/testsupport/package.scala
@@ -17,6 +17,8 @@ import scala.jdk.CollectionConverters._
 
 package object testsupport {
   val ZSpecFQN = "zio.test.RunnableSpec"
+  val DefaultRunnableSpec = "zio.test.DefaultRunnableSpec"
+  val DefaultMutableRunnableSpec = "zio.test.DefaultMutableRunnableSpec"
 
   def parentTypeDefinition(e: PsiElement): Option[ScTypeDefinition] =
     parentOfType(e, classOf[ScTypeDefinition], strict = false)


### PR DESCRIPTION
Defaults to `DefaultRunnableSpec` in the UI, as well as auto-suggesting the `Spec` suffix for new specs.
This should make @kitlangton happi!

But since the implementation is based on the Java-specific tests that don't make much sense in Scala/ZIO - it's possible that the dialog will be bypassed in the future versions, allowing creating a new spec file automagically!

Fixes #298