### PR TITLE
Test runner notifications only for supported versions

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerProjectNotification.scala
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.annotations.NonNls
 import zio.intellij.testsupport.runner.TestRunnerNotifications.{displayError, displayInfo}
 import zio.intellij.testsupport.runner.TestRunnerResolveService.ResolveError
+import zio.intellij.utils.Version.ZIO
 import zio.intellij.utils.{ProjectSyntax, ScalaVersionHack, Version}
 import zio.intellij.{ErrorReporter, ZioIcon}
 
@@ -23,11 +24,14 @@ private[runner] final class TestRunnerProjectNotification(private val project: P
   private def shouldSuggestTestRunner(project: Project, downloadIfMissing: Boolean = false): Boolean =
     project.versions.foldLeft(false) {
       case (flag, (version, scalaVersion)) =>
-        flag | TestRunnerResolveService.instance
+        flag | (supportedRange(version) && TestRunnerResolveService.instance
           .resolve(version, scalaVersion, downloadIfMissing)
           .toOption
-          .isEmpty
+          .isEmpty)
     }
+
+  private def supportedRange(version: Version) =
+    version >= ZIO.`RC18-2` && version.major.value < 2 // ZIO 2.0 (excluding M1) has the IntelliJ-rendering runner built-in
 
   //noinspection HardCodedStringLiteral
   private def href(ref: String, text: String): String = s"""<a href="$ref">$text</a>"""

--- a/src/main/scala/zio/intellij/testsupport/runner/TestRunnerResolveService.scala
+++ b/src/main/scala/zio/intellij/testsupport/runner/TestRunnerResolveService.scala
@@ -1,14 +1,12 @@
 package zio.intellij.testsupport.runner
 
-import java.net.{URL, URLClassLoader}
 import com.intellij.openapi.components.{PersistentStateComponent, ServiceManager, State, Storage}
-import com.intellij.openapi.progress.{ProcessCanceledException, ProgressIndicator, Task}
+import com.intellij.openapi.progress.{ProcessCanceledException, ProgressIndicator}
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.xmlb.XmlSerializerUtil
 import org.jetbrains.annotations.{Nls, NonNls}
 import org.jetbrains.plugins.scala.ScalaVersion
-import org.jetbrains.plugins.scala.extensions.invokeLater
 import org.jetbrains.plugins.scala.util.ScalaCollectionsUtil
 import zio.intellij.testsupport.ZTestRunConfiguration.ZTestRunnerName
 import zio.intellij.testsupport.runner.TestRunnerDownloader.DownloadResult.{DownloadFailure, DownloadSuccess}
@@ -17,6 +15,7 @@ import zio.intellij.testsupport.runner.TestRunnerResolveService.ResolveError.Dow
 import zio.intellij.testsupport.runner.TestRunnerResolveService._
 import zio.intellij.utils.{BackgroundTask, ScalaVersionHack, Version}
 
+import java.net.{URL, URLClassLoader}
 import scala.beans.BeanProperty
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -34,12 +34,7 @@ package object utils {
     def versions: List[(Version, ScalaVersion)] = {
       val sourceModules = project.modulesWithScala.filter(_.isSourceModule).toList
 
-      sourceModules.flatMap { m =>
-        // First ZIO Test runner release: RC18-2
-        // Do not try to download test runner for ZIO versions without runner release
-        val zioVersion = m.zioVersion.filter(_ >= Version.ZIO.`RC18-2`)
-        zioVersion zip m.scalaVersion
-      }.distinct
+      sourceModules.flatMap(m => m.zioVersion zip m.scalaVersion).distinct
     }
 
     def sbtVersion = {


### PR DESCRIPTION
This limits the notification prompts to only known ZIO versions that have the test runner support.
Starting ZIO 2.0 (post M1), the test runner won't be needed and it will have the IntelliJ-specific output rendering built in! (fingers crossed)

Closes #313
Closes #314