### PR TITLE
Detect duplicate issues

### DIFF
--- a/.github/workflows/potential-duplicates.yml
+++ b/.github/workflows/potential-duplicates.yml
@@ -1,0 +1,34 @@
+name: Potential Duplicates
+on:
+  issues:
+    types: [opened, edited]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/potential-duplicates@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Issue title filter work with anymatch https://www.npmjs.com/package/anymatch.
+          # Any matched issue will stop detection immediately.
+          # You can specify multi filters in each line.
+          filter: ''
+          # Exclude keywords in title before detecting.
+          exclude: ''
+          # Label to set, when potential duplicates are detected.
+          label: potential-duplicate
+          # Get issues with state to compare. Supported state: 'all', 'closed', 'open'.
+          state: all
+          # If similarity is higher than this threshold([0,1]), issue will be marked as duplicate.
+          threshold: 0.8
+          # Reactions to be add to comment when potential duplicates are detected.
+          # Available reactions: "-1", "+1", "confused", "laugh", "heart", "hooray", "rocket", "eyes"
+          # reactions: 'eyes, confused'
+          # Comment to post when potential duplicates are detected.
+          comment: >
+            If you came here through the Intellij error reporter, there's a high probability that the issue was already reported.
+            Please check the following list and if you find the same issue already reported, please add any additional information there,
+            and close this issue.
+            Potential duplicates: {{#issues}}
+              - [#{{ number }}] {{ title }} ({{ accuracy }}%)
+            {{/issues}}


### PR DESCRIPTION
The issues section is swamped by duplicates create through Intellij's "Report issue" feature.
This Github actions tries to detect duplicates and posts them as a comment with a call to action to deduplicate.
@hmemcpy hope this one doesn't get covered by the noise 😉 