### PR TITLE
Put first line of exception into issue title

### DIFF
--- a/src/main/scala/zio/intellij/ErrorReporter.scala
+++ b/src/main/scala/zio/intellij/ErrorReporter.scala
@@ -36,7 +36,7 @@ final class ErrorReporter extends ErrorReportSubmitter {
       .toList
 
     try reportErrorOnGithub(
-      "An unhandled exception occurred in the plugin",
+      errors.headOption.map(e => "Unhandled exception: " + e.split("\n", 2).head).getOrElse("An unhandled exception occurred in the plugin"),
       "The following exceptions(s) occurred in the ZIO for IntelliJ plugin:",
       Option(additionalInfo),
       errors,


### PR DESCRIPTION
Hi @hmemcpy, this is just a guess of how one could put errors in the title (see https://github.com/zio/zio-intellij/pull/364#issuecomment-1118369706).
I unfortunately don't have the time to set up a dev env for IntelliJ to test this.
Maybe it helps nonetheless.