### PR TITLE
Add some simple zio live templates

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -316,6 +316,9 @@
         <!-- temporary disabled until I can figure out how to disable on invalid items
         <customLiveTemplate implementation="zio.intellij.postfix.ZPostfixLiveTemplateHack" />
         !-->
+
+        <!-- Live Templates -->
+        <defaultLiveTemplates file="/liveTemplates/zio.xml"/>
     </extensions>
 
 </idea-plugin>

--- a/src/main/resources/liveTemplates/zio.xml
+++ b/src/main/resources/liveTemplates/zio.xml
@@ -1,0 +1,15 @@
+<templateSet group="zio">
+  <template name="zio-for-comp" value="for {&#10;  _ &lt;- ZIO.unit&#10;} yield ???" description="Templates out a ZIO for-comprehension" toReformat="false" toShortenFQNames="true">
+    <context>
+      <option name="SCALA" value="true" />
+    </context>
+  </template>
+  <template name="zio-zlayer" value="ZLayer {&#10;    for {&#10;        $dep$ &lt;- ZIO.service[$depType$]&#10;     } yield $type$($dep$)&#10;}&#10;" description="Templates out a ZLayer when inside the companion object" toReformat="true" toShortenFQNames="true">
+    <variable name="dep" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="depType" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="type" expression="substringBefore(className(), &quot;$&quot;)" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="SCALA_CODE" value="true" />
+    </context>
+  </template>
+</templateSet>


### PR DESCRIPTION
I was about to make my first IntelliJ plugin with some ZIO live templates, and then I thought, "hey, why not just put them here?"

Not sure if there is interest in adding these templates to the official plugin, but I've got a few others as well. I've added two so far:

## zio-for-comp

This generates a small bit of boiler plate for a ZIO for-comprehension. (Please ignore that the zio-zlayer is highlighted from the context menu 😅 )

Example:

<img width="748" alt="Screenshot 2022-12-23 at 11 36 47 AM" src="https://user-images.githubusercontent.com/149476/209372911-a035d2f4-2ff7-4dff-a0a9-5ed0a7edaafd.png">

<img width="725" alt="Screenshot 2022-12-23 at 11 37 30 AM" src="https://user-images.githubusercontent.com/149476/209372918-7d81de8c-69a6-4307-a9b4-dc759e91a43e.png">

## zio-zlayer

This generates a small bit of boiler plate for building a ZLayer from a ZIO for-comprehension.
It stages one dependency (driven by variables), and grabs the resulting type from the companion object it's used in.

Example:

<img width="814" alt="Screenshot 2022-12-23 at 11 46 33 AM" src="https://user-images.githubusercontent.com/149476/209373124-ca70edf8-c7a4-4b38-a41f-70cd51d0947f.png">
<img width="714" alt="Screenshot 2022-12-23 at 11 46 46 AM" src="https://user-images.githubusercontent.com/149476/209373139-3c49f435-b7d9-45df-b9b5-f26ba7788378.png">
<img width="707" alt="Screenshot 2022-12-23 at 11 47 01 AM" src="https://user-images.githubusercontent.com/149476/209373146-32f84172-a666-4e0a-acd4-f8aca473e7f8.png">


If you think these may be useful, I'd be happy to clean them up as needed, and add any others!