### PR TITLE
Support Zlayer type alias inspection

### DIFF
--- a/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
+++ b/src/main/scala/zio/intellij/intentions/ZTypeAnnotationIntention.scala
@@ -2,7 +2,6 @@ package zio.intellij.intentions
 
 import com.intellij.openapi.editor.Editor
 import org.jetbrains.plugins.scala.codeInsight.intention.types._
-import org.jetbrains.plugins.scala.codeInspection.collections.isOfClassFrom
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScBindingPattern, ScTypedPattern, ScWildcardPattern}
 import org.jetbrains.plugins.scala.lang.psi.api.base.types.ScTypeElement
 import org.jetbrains.plugins.scala.lang.psi.api.expr.ScUnderscoreSection
@@ -16,8 +15,8 @@ abstract class ZTypeAnnotationIntention extends AbstractTypeAnnotationIntention 
 
   override protected def descriptionStrategy: Strategy =
     ZStrategy {
-      case (te, declaredType) => isOfClassFrom(declaredType, zioLikePackages) && shouldSuggest(te, declaredType)
-      case _                  => false
+      case (te, tpe) => (fromZioLike(tpe) || fromZioLayer(tpe)) && shouldSuggest(te, tpe)
+      case _         => false
     }
 
   override def invocationStrategy(maybeEditor: Option[Editor]): Strategy =

--- a/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
+++ b/src/main/scala/zio/intellij/intentions/suggestions/SuggestTypeAlias.scala
@@ -95,7 +95,7 @@ object SuggestTypeAlias {
     check(alias, tpe)(_.equiv(tpe))
 
   def conforms(alias: ScTypeAliasDefinition, tpe: ScType): Option[ScType] =
-    check(alias, tpe)(_.conforms(tpe))
+    check(alias, tpe)(tpe.conforms(_))
 
   private def check(alias: ScTypeAliasDefinition, tpe: ScType)(checker: ScType => Boolean) = {
     val undefParams = alias.typeParameters.map(UndefinedType(_))


### PR DESCRIPTION
Closes https://github.com/zio/zio-intellij/issues/405.
Also fixes annoying bug when Intellij was suggesting wrong type aliases (see screenshots, ULayer / UIO should not be suggested)
![image](https://user-images.githubusercontent.com/28982711/222927063-b2c7ad8f-dd2b-40d8-a436-3a21e8f7a9d7.png)
![image](https://user-images.githubusercontent.com/28982711/222927428-f43df33d-86ec-4c2a-a46d-088264d19a38.png)
