### PR TITLE
highlight unused tests

### DIFF
--- a/src/main/scala/org/jetbrains/plugins/scala/codeInspection/codeInspectionHack.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/codeInspection/codeInspectionHack.scala
@@ -1,0 +1,12 @@
+package org.jetbrains.plugins.scala.codeInspection
+
+import org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression
+
+// dirty hack to make expressionResultIsNotUsed public
+// todo use original method directly when (if) it's a public API
+object codeInspectionHack {
+
+  def expressionResultIsNotUsed(expression: ScExpression): Boolean =
+    org.jetbrains.plugins.scala.codeInspection.expressionResultIsNotUsed(expression)
+
+}

--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -367,6 +367,12 @@ package object inspections {
       Some(expr).filter(fromZioLike)
   }
 
+  object zioSpec {
+
+    def unapply(expr: ScExpression): Option[ScExpression] =
+      Some(expr).filter(fromZioSpec)
+  }
+
   val exitCodeSuccess = new ExitCode("success")
   val exitCodeFailure = new ExitCode("failure")
 

--- a/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
+++ b/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
@@ -44,6 +44,9 @@ object TypeCheckUtils {
   def fromZioLayer(tpe: ScType): Boolean =
     isOfClassFrom(tpe, zioLayerTypes)
 
+  def fromZioSpec(r: ScExpression): Boolean =
+    isOfClassFrom(r, zioSpecTypes)
+
   def fromZioSpec(tpe: ScType): Boolean =
     isOfClassFrom(tpe, zioSpecTypes)
 

--- a/src/test/scala/zio/inspections/UnusedZIOExpressionsInspectionTest.scala
+++ b/src/test/scala/zio/inspections/UnusedZIOExpressionsInspectionTest.scala
@@ -4,7 +4,7 @@ import zio.intellij.inspections.mistakes.UnusedZIOExpressionsInspection
 
 class UnusedZIOExpressionsInspectionTest extends ZScalaInspectionTest[UnusedZIOExpressionsInspection] {
 
-  override protected val description = UnusedZIOExpressionsInspection.message
+  override protected val description = UnusedZIOExpressionsInspection.unusedZioExprMessage
 
   def test_two_sibling_effects(): Unit =
     z(s"""${START}putStrLn("")$END
@@ -17,6 +17,10 @@ class UnusedZIOExpressionsInspectionTest extends ZScalaInspectionTest[UnusedZIOE
   def test_zio_effect_and_assert(): Unit =
     z(s"""${START}ZIO.unit$END
          |assert(true)(isTrue)""".stripMargin).assertHighlighted()
+
+  def test_zio_effect_and_just_value(): Unit =
+    z(s"""${START}ZIO.unit$END
+         |1""".stripMargin).assertHighlighted()
 
   def test_entire_scope_highlighted(): Unit =
     z(s"""${START}ZIO.when(true) {
@@ -34,5 +38,46 @@ class UnusedZIOExpressionsInspectionTest extends ZScalaInspectionTest[UnusedZIOE
 
   def test_prefix_operator_should_not_be_highlighted(): Unit =
     z(s"""$START!${END}zio.test.assertCompletes""").assertNotHighlighted()
+
+}
+
+class UnusedZIOSpecInspectionTest extends ZScalaInspectionTest[UnusedZIOExpressionsInspection] {
+
+  override protected val description = UnusedZIOExpressionsInspection.unusedZioSpecMessage
+
+  def test_two_tests(): Unit =
+    z(s"""${START}test("first")(assertTrue(true))$END
+         |test("second")(assertTrue(true))""".stripMargin).assertHighlighted()
+
+  def test_two_suites(): Unit =
+    z(s"""${START}suite("first")(test("first")(assertTrue(true)))$END
+         |suite("second")(test("second")(assertTrue(true)))""".stripMargin).assertHighlighted()
+
+  def test_suite_and_test(): Unit =
+    z(s"""${START}suite("first")(test("first")(assertTrue(true)))$END
+         |test("second")(assertTrue(true))""".stripMargin).assertHighlighted()
+
+  def test_test_and_suite(): Unit =
+    z(s"""${START}test("first")(assertTrue(true))$END
+         |suite("second")(test("second")(assertTrue(true)))""".stripMargin).assertHighlighted()
+
+  def test_test_and_just_value(): Unit =
+    z(s"""${START}test("first")(assertTrue(true))$END
+         |1""".stripMargin).assertHighlighted()
+
+  def test_suite_with_tests_no_highlight(): Unit =
+    z(s"""${START}suite("first")(
+         |  test("first_1")(assertTrue(true)),
+         |  test("first_2")(assertTrue(true))
+         |)$END
+         |""".stripMargin).assertNotHighlighted()
+
+  def test_entire_scope_highlighted(): Unit =
+    z(s"""${START}suite("first")(
+         |  test("first_1")(assertTrue(true)),
+         |  test("first_2")(assertTrue(true))
+         |)$END
+         |suite("second")(test("second")(assertTrue(true)))
+         |""".stripMargin).assertHighlighted()
 
 }


### PR DESCRIPTION
Closes https://github.com/zio/zio-intellij/issues/402
Also improves detection of unused effects, now it can detect cases when effect is unused and followed by non-effect types like this
```scala
ZIO.succeed(1)
println("")
```
But I had to use internal plugin API to make it work :( I could just copy-pasted the whole method (wouldn't be the first time), but decided to use a temp hack. Hopefully it'll become a public API in the nearest releases. If not, we can use good old copy-pasting :)