### PR TITLE
Add provide macro inspection description

### DIFF
--- a/src/main/resources/inspectionDescriptions/ProvideMacroInspection.html
+++ b/src/main/resources/inspectionDescriptions/ProvideMacroInspection.html
@@ -1,0 +1,23 @@
+<html>
+<body>
+Builds a layer tree similar to how ZIO does it to provide hints on missing layers. E.g.
+<pre>
+val eff: ZIO[Int, Nothing, Int] = ZIO.service[Int].debug
+val uio = eff.provide(ZLayer.succeed(""))
+</pre>
+Will raise an error because there is no `Int` in the environment. It can also detect unnecessary extra layers, e.g.
+<br/>
+<pre>
+val eff: ZIO[Int, Nothing, Int] = ZIO.service[Int].debug
+val uio = eff.provide(ZLayer.succeed(1), ZLayer.succeed(""))
+</pre>
+Will complain because `String` is not required and can be removed. And many more!
+<br/>
+Note: if you need to keep some "unused" layer because of their side effects, you should make it return unit. For example,
+<pre>
+val eff: ZIO[Int, Nothing, Int] = ZIO.service[Int].debug
+val uio = eff.provide(ZLayer.succeed(1), ZLayer.fromZIO(ZIO.debug("Hey, I'm a side effect!")))
+</pre>
+will compile fine and not cause any warnings.
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
@@ -3,6 +3,7 @@ package zio.intellij.inspections.macros
 import com.intellij.codeInspection._
 import com.intellij.psi.PsiElement
 import org.jetbrains.plugins.scala.codeInspection.PsiElementVisitorSimple
+import org.jetbrains.plugins.scala.extensions.PsiElementExt
 import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScGenericCall, ScMethodCall}
 import org.jetbrains.plugins.scala.lang.psi.impl.ScalaPsiElementFactory.{
   createExpressionFromText,
@@ -25,7 +26,8 @@ class ProvideMacroInspection extends LocalInspectionTool {
 
   override def buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitorSimple = element => {
     val module = element.module
-    if (module.exists(_.isZio1)) visitZIO1ProvideMethods(holder)(element)
+    if (element.isInScala3File) () // inspection causes lots of false positives in Scala 3. Disable until better times
+    else if (module.exists(_.isZio1)) visitZIO1ProvideMethods(holder)(element)
     else if (module.exists(_.isZio2)) visitZIO2ProvideMethods(holder)(element)
   }
 


### PR DESCRIPTION
Closes https://github.com/zio/zio-intellij/issues/420
Also disables this inspection for Scala 3 (see https://github.com/zio/zio-intellij/issues/412). Today I've had an opportunity to use it with Scala 3 and it, indeed, causes a lot of false positives.