### PR TITLE
Use HTML entities for less-than symbol in inspection descriptions

### DIFF
--- a/src/main/resources/inspectionDescriptions/DiscardingZIOForBindingInspection.html
+++ b/src/main/resources/inspectionDescriptions/DiscardingZIOForBindingInspection.html
@@ -3,9 +3,9 @@
 Detects if an effect is suspiciously used in for-comprehension as a simple binding and not as a generator:
 <pre>
 for {
-  a <- ZIO.succeed(1)
+  a &lt;- ZIO.succeed(1)
   _ = ZIO.logInfo("msg")
-  b <- ZIO.succeed(1)
+  b &lt;- ZIO.succeed(1)
 } yield a + b
 </pre>
 <br/>
@@ -13,9 +13,9 @@ Will highlight the expression <code>_ = ZIO.logInfo("msg")</code>.<br/>
 Fix by using generator syntax:
 <pre>
 for {
-  a <- ZIO.succeed(1)
-  _ <- ZIO.logInfo("msg")
-  b <- ZIO.succeed(1)
+  a &lt;- ZIO.succeed(1)
+  _ &lt;- ZIO.logInfo("msg")
+  b &lt;- ZIO.succeed(1)
 } yield a + b
 </pre>
 

--- a/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
+++ b/src/main/resources/inspectionDescriptions/IfGuardInsteadOfWhenInspection.html
@@ -5,14 +5,14 @@ Detects if guards mistakenly used in for-comprehension on ZIO effect causing <co
 The guard expression in the following code snippet will be highlighted:
 <pre>
 for {
-    _ <- myService.executeSomething() if config.somethingShouldBeExecuted
+    _ &lt;- myService.executeSomething() if config.somethingShouldBeExecuted
 } yield ???
 </pre>
 <br/>
 And you will also be prompted to fix it using <code>ZIO.when</code>:
 <pre>
 for {
-    _ <- myService.executeSomething().when(config.somethingShouldBeExecuted)
+    _ &lt;- myService.executeSomething().when(config.somethingShouldBeExecuted)
 } yield ???
 </pre>
 <p>
@@ -20,11 +20,11 @@ for {
 <ul>
     <li>Not assigned to a variable, e.g.:
     <pre>
-    _ <- myService.executeSomething() if config.somethingShouldBeExecuted
+    _ &lt;- myService.executeSomething() if config.somethingShouldBeExecuted
     </pre>
         will be highlighted, while
     <pre>
-    executionResult <- myService.executeSomething() if config.somethingShouldBeExecuted
+    executionResult &lt;- myService.executeSomething() if config.somethingShouldBeExecuted
     </pre>
         will not.
     </li>

--- a/src/main/resources/inspectionDescriptions/WrapInsteadOfLiftInspection.html
+++ b/src/main/resources/inspectionDescriptions/WrapInsteadOfLiftInspection.html
@@ -29,14 +29,14 @@ ZIO.fromFuture(implicit ec => myFuture)
     <li>Do not have usages, e.g.:
     <pre>
     for {
-      a <- ZIO(Option(1))
+      a &lt;- ZIO(Option(1))
     } yield ???
     </pre>
     will be highlighted, while
     <pre>
     for {
-      a <- ZIO(Option(1))
-      b <- doSomethingWith(a)
+      a &lt;- ZIO(Option(1))
+      b &lt;- doSomethingWith(a)
     } yield ???
     </pre>
     will not.

--- a/src/main/resources/inspectionDescriptions/YieldingZIOEffectInspection.html
+++ b/src/main/resources/inspectionDescriptions/YieldingZIOEffectInspection.html
@@ -3,8 +3,8 @@
 Detects if a value returned from the yield part of a for comprehension is explicitly wrapped in a ZIO effect:
 <pre>
 for {
-    x <- ZIO.succeed(1)
-    y <- ZIO.succeed(2)
+    x &lt;- ZIO.succeed(1)
+    y &lt;- ZIO.succeed(2)
 } yield {
     ZIO.effect(x + y)
 }
@@ -14,9 +14,9 @@ Will highlight the expression <code>ZIO.effect(x + y)</code>.<br/>
 Fix by moving effect from yield inside of the for:
 <pre>
 for {
-    x <- ZIO.succeed(1)
-    y <- ZIO.succeed(2)
-    res <- ZIO.effect(x + y)
+    x &lt;- ZIO.succeed(1)
+    y &lt;- ZIO.succeed(2)
+    res &lt;- ZIO.effect(x + y)
 } yield res
 </pre>
 


### PR DESCRIPTION
`<` in HTML text is not rendered. Instead we should use `&lt;`.

I did a replace-all against all occurrences of `<-` inside `src/main/resources/inspectionDescriptions`. Searching for `<` inside HTML is a bit tougher. I've searched for `<` wrapped in spaces and those do not occur in your descriptions, but if you know you have other cases of `<` outside tags, you might want to replace them as well.

I haven't tested my changes on this particular plugin, so please double-check before merging. What I can say is that it's what we do in the IntelliJ Scala plugin's inspection descriptions.