### PR TITLE
Fix Ambiguous Layers error for collision names from different dirs

### DIFF
--- a/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
@@ -502,7 +502,7 @@ object LayerBuilder {
 
   // dirty hack to make it work
   // ScType and ScExpression don't have equals / hashCode methods, which makes it difficult to use it with the algorithm
-  // besides, original ZIO algorithm uses string comparison too
+  // use canonicalText for comparison to avoid name collisions
   // also, ZType is guaranteed to have meaningful type (non-Any)
   final class ZType private (val value: ScType)(implicit context: TypePresentationContext) {
     def isSubtypeOf(that: ZType): Boolean = this.value.conforms(that.value)
@@ -515,7 +515,7 @@ object LayerBuilder {
     override def toString: String = asStr
 
     private lazy val widened = value.widen
-    private lazy val asStr   = resolveAliases(widened).getOrElse(widened).presentableText
+    private lazy val asStr   = resolveAliases(widened).getOrElse(widened).canonicalText
   }
 
   object ZType {

--- a/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
@@ -143,6 +143,26 @@ abstract class ProvideMacroInspectionTest(val provide: String) extends ProvideMa
        |effect.$provide(layer1, ${r("layer2")})""".stripMargin
   }.assertHighlighted()
 
+  def testTheSameNameNoHighlighting(): Unit =
+    s"""$imports
+       |import zio._
+       |
+       |package foo {
+       | class Bar
+       | val bar = ZLayer.succeed(new Bar)
+       |}
+       |
+       |package buzz {
+       | class Bar
+       | val bar = ZLayer.succeed(new Bar)
+       |}
+       |
+       |object Test {
+       | val effect: URIO[${Has("foo.Bar")} with ${Has("buzz.Bar")}, Unit] = ???
+       | effect.$provide(${r("foo.bar")}, ${r("buzz.bar")})
+       |}""".stripMargin
+      .assertNotHighlighted()
+
 }
 
 class ProvideMacroZIO1InspectionTest extends ProvideMacroInspectionTest("inject") {


### PR DESCRIPTION
When we have to provide layers with the same names, it highlighted with Ambiguous layers