### PR TITLE
Fix provide inspection rendering

### DIFF
--- a/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
@@ -508,14 +508,17 @@ object LayerBuilder {
     def isSubtypeOf(that: ZType): Boolean = this.value.conforms(that.value)
 
     override def equals(other: Any): Boolean = other match {
-      case that: ZType => this.asStr == that.asStr
+      case that: ZType => this.canonicalText == that.canonicalText
       case _           => false
     }
-    override def hashCode(): Int  = asStr.hashCode
-    override def toString: String = asStr
+    override def hashCode: Int    = canonicalText.hashCode
+    override def toString: String = presentableText
 
-    private lazy val widened = value.widen
-    private lazy val asStr   = resolveAliases(widened).getOrElse(widened).canonicalText
+    private lazy val widened   = value.widen
+    private lazy val dealiased = resolveAliases(widened).getOrElse(widened)
+
+    private lazy val canonicalText   = dealiased.canonicalText
+    private lazy val presentableText = dealiased.presentableText
   }
 
   object ZType {

--- a/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/macros/ProvideMacroInspection.scala
@@ -268,7 +268,7 @@ final case class LayerBuilder(
   sideEffectNodes: List[Node],
   method: ProvideMethod,
   typeToLayer: ZType => String
-)(implicit tpContext: TypePresentationContext, pContext: ProjectContext, scalaFeatures: ScalaFeatures) {
+)(implicit pContext: ProjectContext, scalaFeatures: ScalaFeatures) {
 
   def tryBuild: Either[ConstructionIssue, Unit] = assertNoAmbiguity.flatMap(_ => tryBuildInternal)
 
@@ -332,9 +332,9 @@ final case class LayerBuilder(
     val unusedRemainderLayers = remainderNodes.filterNot(node => usedLayers(node.value))
     val unusedRemainderLayersWarning =
       method match {
-        case ProvideMethod.Provide => None
-        case ProvideMethod.ProvideSome | ProvideMethod.ProvideSomeShared =>
-          Option.when(!method.isProvideSomeShared && unusedRemainderLayers.nonEmpty) {
+        case ProvideMethod.Provide | ProvideMethod.ProvideSomeShared => None
+        case ProvideMethod.ProvideSome =>
+          Option.when(unusedRemainderLayers.nonEmpty) {
             UnusedProvideSomeLayersWarning(unusedRemainderLayers.map(node => node.outputs.head))
           }
         case ProvideMethod.ProvideCustom =>
@@ -525,7 +525,7 @@ object LayerBuilder {
 
   }
 
-  final class ZExpr(val value: ScExpression)(implicit context: TypePresentationContext) {
+  final class ZExpr(val value: ScExpression) {
     override def equals(other: Any): Boolean = other match {
       case that: ZExpr => this.asStr == that.asStr
       case _           => false

--- a/src/main/scala/zio/intellij/postfix/ZPostfixLiveTemplateHack.scala
+++ b/src/main/scala/zio/intellij/postfix/ZPostfixLiveTemplateHack.scala
@@ -7,12 +7,10 @@ import com.intellij.codeInsight.template.postfix.completion.PostfixTemplateLooku
 import com.intellij.codeInsight.template.postfix.templates.{PostfixLiveTemplate, PostfixTemplatesUtils}
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.util.{Disposer, Iconable}
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiFile
-import org.jetbrains.plugins.scala.project.ProjectPsiFileExt
-import zio.intellij.ZioIcon
 import zio.intellij.intentions.ZIcon
-import zio.intellij.utils.ModuleSyntax
+import zio.intellij.utils.PsiElementSyntax
 
 import java.util
 import java.util.Collections
@@ -30,7 +28,7 @@ private[this] class ZPostfixLiveTemplateHack extends PostfixLiveTemplate {
     editor: Editor,
     offset: Int
   ): util.Collection[_ <: CustomLiveTemplateLookupElement] = {
-    if (!file.module.exists(_.hasZio)) return Collections.emptyList
+    if (!file.hasZio) return Collections.emptyList
 
     val result           = new util.HashSet[CustomLiveTemplateLookupElement]
     val callback         = new CustomTemplateCallback(editor, file)

--- a/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
@@ -19,7 +19,7 @@ class MockableInjector extends SyntheticMembersInjector {
   override def injectSupers(source: ScTypeDefinition): Seq[String] =
     MockableInjector.findMacroAnnotationTypeElement(source) match {
       case Some((_, serviceClassName)) =>
-        if (source.module.exists(_.isZio2)) Seq(s"zio.mock.Mock[$serviceClassName]")
+        if (source.isZio2) Seq(s"zio.mock.Mock[$serviceClassName]")
         else Seq(s"zio.test.mock.Mock[zio.Has[$serviceClassName]]")
       case _ => Seq.empty
     }
@@ -37,7 +37,7 @@ class MockableInjector extends SyntheticMembersInjector {
   override def injectMembers(source: ScTypeDefinition): Seq[String] =
     MockableInjector.findMacroAnnotationTypeElement(source) match {
       case Some((_, serviceClassName)) =>
-        if (source.module.exists(_.isZio2))
+        if (source.isZio2)
           Seq(s"val compose: zio.URLayer[zio.mock.Proxy, $serviceClassName] = ???")
         else
           Seq(s"val compose: zio.URLayer[zio.Has[zio.test.mock.Proxy], zio.Has[$serviceClassName]] = ???")
@@ -51,7 +51,7 @@ object MockableInjector {
   private[this] val mockable2Annotation = "zio.mock.mockable"
 
   def findMacroAnnotationTypeElement(source: ScTypeDefinition): Option[(ScTypeElement, String)] = {
-    val annotation = if (source.module.exists(_.isZio2)) mockable2Annotation else mockableAnnotation
+    val annotation = if (source.isZio2) mockable2Annotation else mockableAnnotation
     Option(source.findAnnotationNoAliases(annotation)).flatMap {
       case a: ScAnnotation =>
         a.typeElement match {

--- a/src/main/scala/zio/intellij/utils/package.scala
+++ b/src/main/scala/zio/intellij/utils/package.scala
@@ -27,7 +27,14 @@ import org.jetbrains.plugins.scala.lang.psi.types.result.Typeable
 import org.jetbrains.plugins.scala.lang.refactoring.ScTypePresentationExt
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
 import org.jetbrains.plugins.scala.project.settings.ScalaCompilerConfiguration
-import org.jetbrains.plugins.scala.project.{LibraryExt, ModuleExt, ProjectContext, ProjectExt, ScalaLanguageLevel}
+import org.jetbrains.plugins.scala.project.{
+  LibraryExt,
+  ModuleExt,
+  ProjectContext,
+  ProjectExt,
+  ProjectPsiElementExt,
+  ScalaLanguageLevel
+}
 import org.jetbrains.sbt.SbtUtil
 import org.jetbrains.sbt.SbtUtil.getDefaultLauncher
 import org.jetbrains.sbt.project.SbtExternalSystemManager
@@ -288,6 +295,12 @@ package object utils {
     }
 
     def isPrerelease = version < Version.scala3Version
+  }
+
+  implicit class PsiElementSyntax(private val element: PsiElement) extends AnyVal {
+    def hasZio: Boolean = element.module.exists(_.hasZio)
+    def isZio1: Boolean = element.module.exists(_.isZio1)
+    def isZio2: Boolean = element.module.exists(_.isZio2)
   }
 
   implicit class TraverseAtHome[A](private val list: List[A]) extends AnyVal {

--- a/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
@@ -518,3 +518,29 @@ abstract class ProvideSomeMacroZIO2SpecInspectionTestBase(val provideSome: Strin
 class ProvideSomeMacroZIO2SpecInspectionTest extends ProvideSomeMacroZIO2SpecInspectionTestBase("provideSome")
 class ProvideSomeSharedMacroZIO2SpecInspectionTest
     extends ProvideSomeMacroZIO2SpecInspectionTestBase("provideSomeShared")
+
+// special test to expect _very_ specific error message
+// checking if types are rendered correctly
+class ProvideMacroInspectionRenderingTest extends ZScalaInspectionTest[ProvideMacroInspection] {
+  override def isZIO1: Boolean = false
+
+  // not 1. _root_.foo.Bar
+  override protected def description =
+  """Please provide layers for the following type:1. Bar""".stripMargin
+
+  override protected def descriptionMatches(s: String): Boolean =
+    s != null && (s.filterNot(c => c == '\r' || c == '\n') == description)
+
+  def testCircularityTopLevelHighlight(): Unit =
+    s"""import zio._
+       |
+       |package foo {
+       | class Bar
+       |}
+       |
+       |object Test {
+       | val effect: URIO[foo.Bar, Unit] = ???
+       | ${r("effect.provide()")}
+       |}""".stripMargin.assertHighlighted()
+
+}

--- a/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
@@ -22,10 +22,6 @@ abstract class ProvideMacroInspectionTestBase extends ZScalaInspectionTest[Provi
   override protected def descriptionMatches(s: String): Boolean =
     s != null && allPossibleErrors.exists(s.startsWith)
 
-  protected def r(str: String): String = s"$START$str$END"
-
-  protected def Has(tpe: String): String = if (isZIO1) s"Has[$tpe]" else tpe
-
   protected val imports: String = if (isZIO1) "import zio.magic._" else ""
 
 }
@@ -443,8 +439,6 @@ abstract class ProvideMacroSpecInspectionTestBase extends ZScalaInspectionTest[P
 
   override protected def description                            = "Please provide layers for the following"
   override protected def descriptionMatches(s: String): Boolean = s != null && s.startsWith(description)
-
-  protected def r(str: String): String = s"$START$str$END"
 }
 
 abstract class ProvideMacroZIO1SpecInspectionTestBase(val provide: String) extends ProvideMacroSpecInspectionTestBase {

--- a/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
@@ -47,6 +47,12 @@ trait ZInspectionTestBase[T <: LocalInspectionTool] { base: ScalaInspectionTestB
        |}
        |""".stripMargin
 
+  def Has(tpe: String): String = if (isZIO1) s"Has[$tpe]" else tpe
+
+  def range(str: String): String = s"$START$str$END"
+
+  @inline def r(str: String): String = range(str)
+
   implicit protected class S(s: String) {
     def assertHighlighted(): Unit = checkTextHasError(s)
 


### PR DESCRIPTION
Follows up https://github.com/zio/zio-intellij/pull/425
We forgot that `.toString` is actually used not only for a debug, but also for message rendering (which Intellij didn't find since it was used as a part of string interpolation).
![image](https://user-images.githubusercontent.com/28982711/231550216-19463709-54dd-4e27-9449-262fa8beaa42.png)
Added a test for this case to ensure it won't happen in the future. Also made some clean ups and small refactorings.