### PR TITLE
429 propagate context to reneder param type correctly

### DIFF
--- a/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
@@ -184,7 +184,7 @@ object MockableInjector {
           param       <- clause.parameters
           paramType   <- param.paramType
           tpe         <- paramType.typeElement.`type`().toOption
-          presentation = defaultPresentationStringForScalaType(tpe)
+          presentation = defaultPresentationStringForScalaType(tpe)(paramType)
         } yield presentation
       case _ => Seq.empty
     })

--- a/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/MockableInjector.scala
@@ -170,7 +170,7 @@ object MockableInjector {
       case Method(_) | Field(_) => true
       case _                    => false
     }
-      .flatMap(MemberInfo.apply(_))
+      .flatMap(MemberInfo.apply)
       .groupBy(_.signature.name)
 
   private def sortOverloads(infos: Seq[MemberInfo]): Seq[MemberInfo] = {

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
@@ -66,8 +66,8 @@ abstract class ModulePatternAccessibleBase extends SyntheticMembersInjector {
       def returnType(typeInfo: TypeInfo) =
         s"${typeInfo.zioObject}[$requiredEnv" +
           s"${if (typeInfo.rTypeParam.isAny) ""
-          else s" with ${defaultPresentationStringForScalaType(typeInfo.rTypeParam)}"}, " +
-          s"${typeInfo.otherTypeParams.map(defaultPresentationStringForScalaType).mkString(", ")}]"
+          else s" with ${defaultPresentationStringForScalaType(typeInfo.rTypeParam)(sco)}"}, " +
+          s"${typeInfo.otherTypeParams.map(defaultPresentationStringForScalaType(_)(sco)).mkString(", ")}]"
 
       methods.collect {
         case Field(field) =>

--- a/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/ModulePatternAccessibleBase.scala
@@ -180,6 +180,6 @@ abstract class ModulePatternAccessibleBase extends SyntheticMembersInjector {
     }
   }
 
-  override def needsCompanionObject(source: ScTypeDefinition) =
+  override def needsCompanionObject(source: ScTypeDefinition): Boolean =
     source.findAnnotationNoAliases(macroName) != null
 }

--- a/src/main/scala/zio/intellij/synthetic/macros/utils/presentation/presentation.scala
+++ b/src/main/scala/zio/intellij/synthetic/macros/utils/presentation/presentation.scala
@@ -11,8 +11,10 @@ import org.jetbrains.plugins.scala.lang.refactoring.util.ScTypeUtil
 //  Taken from different versions of Scala plugin source code for compatibility.
 package object presentation {
 
-  private[macros] def defaultPresentationStringForScalaType(scType: ScType): String =
-    scType.presentableText(TypePresentationContext.emptyContext)
+  private[macros] def defaultPresentationStringForScalaType(
+    scType: ScType
+  )(implicit context: TypePresentationContext): String =
+    scType.presentableText
 
   private[macros] def presentationStringForScalaParameters(parameters: ScParameters): String =
     parameters.clauses.map(presentationStringForScalaParameterClause).mkString
@@ -45,6 +47,8 @@ package object presentation {
   ): String = tParams.map(presentationStringForScalaTypeParam(_, showVariance)).mkString("[", ", ", "]")
 
   private[macros] def presentationStringForScalaTypeParam(param: ScTypeParam, showVariance: Boolean): String = {
+    implicit val context: TypePresentationContext = TypePresentationContext(param)
+
     val initialText = if (showVariance) {
       if (param.isContravariant) "-"
       else if (param.isCovariant) "+"
@@ -79,6 +83,8 @@ package object presentation {
   }
 
   private def renderAnnotation(annotation: ScAnnotation): String = {
+    implicit val context: TypePresentationContext = TypePresentationContext(annotation)
+
     val buffer = new StringBuilder("@")
 
     val constrInvocation = annotation.constructorInvocation
@@ -100,6 +106,8 @@ package object presentation {
   }
 
   private def parameterTypeAnnotations(param: ScParameter): String = {
+    implicit val context: TypePresentationContext = TypePresentationContext(param)
+
     val typeText          = defaultPresentationStringForScalaType(param.`type`().getOrAny)
     val typeTextDecorated = decoratedParameterType(param, typeText)
     s": $typeTextDecorated"

--- a/src/test/scala/zio/macros/ModulePatternAccessiblePolyTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessiblePolyTest.scala
@@ -43,35 +43,35 @@ abstract class ModulePatternAccessiblePolyTestBase(injectAlias: Boolean) extends
 
   def test_generates_accessor_function_for_field_of_the_polymorphic_service(): Unit =
     assertEquals(
-      s"def v[R, T <: Example.Foo]: zio.ZIO[$aliasOrHasService with R, Throwable, T] = " +
+      s"def v[R, T <: Foo]: zio.ZIO[$aliasOrHasService with R, Throwable, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].v)",
       method("v").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_without_argument_lists(): Unit =
     assertEquals(
-      s"def f1[R, T <: Example.Foo]: zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f1[R, T <: Foo]: zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f1)",
       method("f1").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_with_empty_argument_list(): Unit =
     assertEquals(
-      s"def f2[R, T <: Example.Foo](): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f2[R, T <: Foo](): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f2())",
       method("f2").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_with_single_argument(): Unit =
     assertEquals(
-      s"def f3[R, T <: Example.Foo](t: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f3[R, T <: Foo](t: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f3(t))",
       method("f3").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_with_multiple_argument_lists(): Unit =
     assertEquals(
-      s"def f4[R, T <: Example.Foo](t1: T)(t2: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f4[R, T <: Foo](t1: T)(t2: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f4(t1)(t2))",
       method("f4").getText
     )
@@ -79,35 +79,35 @@ abstract class ModulePatternAccessiblePolyTestBase(injectAlias: Boolean) extends
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_with_multiple_argument_lists_including_implicits()
     : Unit =
     assertEquals(
-      s"def f5[R, T <: Example.Foo](t1: T)(implicit t2: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f5[R, T <: Foo](t1: T)(implicit t2: T): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f5(t1)(t2))",
       method("f5").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_with_varargs(): Unit =
     assertEquals(
-      s"def f6[R, T <: Example.Foo](t: T*): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
+      s"def f6[R, T <: Foo](t: T*): zio.ZIO[$aliasOrHasService, Nothing, T] = " +
         "zio.ZIO.accessM(_.get[Example.Service[R, T]].f6(t: _*))",
       method("f6").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_returning_managed(): Unit =
     assertEquals(
-      s"def f7[R, T <: Example.Foo](t: T): zio.ZManaged[$aliasOrHasService, String, T] = " +
+      s"def f7[R, T <: Foo](t: T): zio.ZManaged[$aliasOrHasService, String, T] = " +
         "zio.ZManaged.accessManaged(_.get[Example.Service[R, T]].f7(t))",
       method("f7").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_returning_sink(): Unit =
     assertEquals(
-      s"def f8[R, T <: Example.Foo](t: T): zio.stream.ZSink[$aliasOrHasService with R, String, T, T, List[T]] = " +
+      s"def f8[R, T <: Foo](t: T): zio.stream.ZSink[$aliasOrHasService with R, String, T, T, List[T]] = " +
         "zio.stream.ZSink.accessSink(_.get[Example.Service[R, T]].f8(t))",
       method("f8").getText
     )
 
   def test_generates_accessor_function_for_method_of_the_polymorphic_service_returning_stream(): Unit =
     assertEquals(
-      s"def f9[R, T <: Example.Foo](t: T): zio.stream.ZStream[$aliasOrHasService, String, T] = " +
+      s"def f9[R, T <: Foo](t: T): zio.stream.ZStream[$aliasOrHasService, String, T] = " +
         "zio.stream.ZStream.accessStream(_.get[Example.Service[R, T]].f9(t))",
       method("f9").getText
     )

--- a/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
+++ b/src/test/scala/zio/macros/ModulePatternAccessibleTest.scala
@@ -87,7 +87,7 @@ object E${CARET}xample {
 
   def test_generates_accessor_function_for_generic_ZIO_method_with_type_constraints(): Unit =
     assertEquals(
-      s"def m3[T <: Example.Foo](t: Example.Wrapped[T]): zio.ZIO[$aliasOrHasService, String, List[T]] = " +
+      s"def m3[T <: Foo](t: Wrapped[T]): zio.ZIO[$aliasOrHasService, String, List[T]] = " +
         "zio.ZIO.accessM(_.get[Example.Service].m3[T](t))",
       method("m3").getText
     )


### PR DESCRIPTION
Fixes https://github.com/zio/zio-intellij/issues/429
Though I have no idea how to write a test for it ¯\\\_(ツ)\_/¯ It looks like it breaks only when `package object` is placed in a separate file