### PR TITLE
fix tests compilation

### DIFF
--- a/src/test/scala/intellij/testfixtures/ScalaSDKLoader.scala
+++ b/src/test/scala/intellij/testfixtures/ScalaSDKLoader.scala
@@ -8,10 +8,9 @@ import java.{util => ju}
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.roots.ui.configuration.libraryEditor.ExistingLibraryEditor
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.{JarFileSystem, VirtualFile}
 import com.intellij.testFramework.PsiTestUtil
-import org.jetbrains.plugins.scala.extensions.ObjectExt
+import org.jetbrains.plugins.scala.extensions.{inWriteAction, ObjectExt}
 import org.jetbrains.plugins.scala.project.{ModuleExt, ScalaLanguageLevel, ScalaLibraryProperties, ScalaLibraryType, template}
 import org.junit.Assert._
 


### PR DESCRIPTION
Previous methods were brutally removed [here](https://github.com/JetBrains/intellij-scala/commit/052c2cf18356a3cdeba92f4e248a9873afde7b73).