### PR TITLE
456 suggest ZIO combinators when using ZIO2

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -81,6 +81,12 @@
                          shortName="SimplifySucceedEitherInspection" level="WARNING"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedUnitInspection"
+                         displayName="Simplify simple unit values to ZIO.unit" groupPath="Scala,ZIO"
+                         groupName="Simplifications"
+                         shortName="SimplifySucceedUnitInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
         <localInspection implementationClass="zio.intellij.inspections.simplifications.SimplifySucceedOptionInspection"
                          displayName="Simplify optional values to .none/.some" groupPath="Scala,ZIO"
                          groupName="Simplifications"

--- a/src/main/resources/inspectionDescriptions/SimplifySucceedOptionInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifySucceedOptionInspection.html
@@ -1,13 +1,17 @@
 <html>
 <body>Simplify the following expressions to use <code>.none</code>/<code>.some</code> instead:
 <pre>
-ZIO.succeed(None)    -> ZIO.none
-UIO(None)            -> ZIO.none
-UIO.apply(None)      -> ZIO.none
+ZIO.succeed(None)     -> ZIO.none
+UIO(None)             -> ZIO.none
+UIO.apply(None)       -> ZIO.none
+ZIO.attempt(None)     -> ZIO.none
+ZIO.effect(None)      -> ZIO.none
+ZIO.effectTotal(None) -> ZIO.none
 
 ZIO.succeed(Some(a)) -> ZIO.some(a)
 UIO(Some(a))         -> ZIO.some(a)
 UIO.apply(Some(a))   -> ZIO.some(a)
 </pre>
+Note that some methods depend on project ZIO version
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/SimplifySucceedUnitInspection.html
+++ b/src/main/resources/inspectionDescriptions/SimplifySucceedUnitInspection.html
@@ -1,0 +1,13 @@
+<html>
+<body>Simplify the following expressions to use <code>.unit</code> instead:
+<pre>
+ZIO.succeed(())     -> ZIO.unit
+UIO(())             -> UIO.unit
+ZIO.apply(())       -> ZIO.unit
+ZIO.attempt(())     -> ZIO.unit
+ZIO.effect(())      -> ZIO.unit
+ZIO.effectTotal(()) -> ZIO.unit
+</pre>
+Note that some methods depend on project ZIO version
+</body>
+</html>

--- a/src/main/scala/zio/intellij/inspections/mistakes/WrapInsteadOfLiftInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/WrapInsteadOfLiftInspection.scala
@@ -93,7 +93,7 @@ final class QuickFix(
 
   override protected def doApplyFix(element: ScExpression)(implicit project: Project): Unit =
     element.replace(
-      createExpressionFromText(s"${zioType.name}.from$wrappedEffect($prefix${replaceWith.getText}", element)(
+      createExpressionFromText(s"${zioType.name}.from$wrappedEffect($prefix${replaceWith.getText})", element)(
         element.projectContext
       )
     )

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyOrElseInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyOrElseInspection.scala
@@ -14,7 +14,9 @@ object OrElseFailSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] = {
     def blockReplacement(zio: ScExpression, body: Seq[ScBlockStatement]): Simplification = {
-      val separator = System.lineSeparator
+      // new Intellij version doesn't seem to like Windows line separators
+      // if ScalaPsiElementFactory.createBlockWithGivenExpressions can use "\n", so can we
+      val separator = "\n"
       val blockBody = body.map(_.getText).mkString(separator, separator, separator)
       replace(expr).withText(s"${zio.getText}.$replaceWith {$blockBody}")
     }

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedOptionInspection.scala
@@ -17,9 +17,12 @@ object NoneSimplificationType extends SimplificationType {
 
   override def getSimplification(expr: ScExpression): Option[Simplification] =
     expr match {
-      case `ZIO.succeed`(zioType, scalaNone())              => Some(replacement(zioType, expr))
-      case `ZIO.apply`(zioType @ (UIO | URIO), scalaNone()) => Some(replacement(zioType, expr))
-      case _                                                => None
+      case `ZIO.succeed`(zioType, scalaNone())     => Some(replacement(zioType, expr))
+      case `ZIO.apply`(zioType, scalaNone())       => Some(replacement(zioType, expr))
+      case `ZIO.attempt`(zioType, scalaNone())     => Some(replacement(zioType, expr))
+      case `ZIO.effect`(zioType, scalaNone())      => Some(replacement(zioType, expr))
+      case `ZIO.effectTotal`(zioType, scalaNone()) => Some(replacement(zioType, expr))
+      case _                                       => None
     }
 }
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedUnitInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifySucceedUnitInspection.scala
@@ -1,0 +1,34 @@
+package zio.intellij.inspections.simplifications
+
+import org.jetbrains.plugins.scala.codeInspection.collections._
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScUnitExpr}
+import zio.intellij.inspections._
+import zio.intellij.utils.types.ZioType
+
+class SimplifySucceedUnitInspection extends ZInspection(SucceedUnitSimplificationType)
+
+object SucceedUnitSimplificationType extends SimplificationType {
+  override def hint: String = "Replace with ZIO.unit"
+
+  private def replacement(zioType: ZioType, expr: ScExpression): Simplification =
+    replace(expr).withText(s"${zioType.name}.unit").highlightAll
+
+  override def getSimplification(expr: ScExpression): Option[Simplification] =
+    expr match {
+      case `ZIO.succeed`(zioType, scalaUnit())     => Some(replacement(zioType, expr))
+      case `ZIO.apply`(zioType, scalaUnit())       => Some(replacement(zioType, expr))
+      case `ZIO.attempt`(zioType, scalaUnit())     => Some(replacement(zioType, expr))
+      case `ZIO.effect`(zioType, scalaUnit())      => Some(replacement(zioType, expr))
+      case `ZIO.effectTotal`(zioType, scalaUnit()) => Some(replacement(zioType, expr))
+      case _                                       => None
+    }
+
+  private object scalaUnit {
+    def unapply(expr: ScExpression): Boolean =
+      expr match {
+        case _: ScUnitExpr => true
+        case _             => false
+      }
+  }
+
+}

--- a/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
+++ b/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
@@ -8,7 +8,10 @@ import zio.intellij.utils.types.{ZLayerTypes, ZioTypes}
 
 object TypeCheckUtils {
 
-  val zioTypes        = ZioTypes.values.map(_.fqName) :+ "zio.ZIOVersionSpecific"
+  val zioCompanionSpecificTypes      = List("zio.ZIOCompanionVersionSpecific", "zio.ZIOCompanionPlatformSpecific")
+  val zioLayerCompanionSpecificTypes = List("zio.ZLayerCompanionVersionSpecific")
+
+  val zioTypes        = ZioTypes.values.map(_.fqName) :+ "zio.ZIOPlatformSpecific" :+ "zio.ZIOVersionSpecific"
   val zioLayerTypes   = ZLayerTypes.values.map(_.fqName)
   val zioSinkTypes    = List("zio.stream.ZSink")
   val zioStreamTypes  = List("zio.stream.ZStream")

--- a/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedEitherInspectionTest.scala
@@ -7,7 +7,7 @@ abstract class SimplifySucceedEitherInspectionTest(s: String)
   override protected val hint = s"Replace with $s"
 }
 
-class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO.left") {
+abstract class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO.left") {
 
   def test_succeed_Left(): Unit = {
     z(s"${START}ZIO.succeed(Left(a))$END").assertHighlighted()
@@ -81,6 +81,11 @@ class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO
     testQuickFix(text, result, hint)
   }
 
+}
+
+class SucceedLeftInspectionTestZIO1 extends SucceedLeftInspectionTest {
+  override protected def isZIO1 = true
+
   def test_UIO_Left(): Unit = {
     z(s"${START}UIO(Left(a))$END").assertHighlighted()
     val text   = z("UIO(Left(a))")
@@ -108,9 +113,14 @@ class SucceedLeftInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO
     val result = z("UIO.left(a)")
     testQuickFix(text, result, hint)
   }
+
 }
 
-class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO.right") {
+class SucceedLeftInspectionTestZIO2 extends SucceedLeftInspectionTest {
+  override protected def isZIO1 = false
+}
+
+abstract class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZIO.right") {
 
   def test_succeed_Right(): Unit = {
     z(s"${START}ZIO.succeed(Right(a))$END").assertHighlighted()
@@ -183,6 +193,10 @@ class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZI
     }
     testQuickFix(text, result, hint)
   }
+}
+
+class SucceedRightInspectionTestZIO1 extends SucceedRightInspectionTest {
+  override protected def isZIO1 = true
 
   def test_UIO_Right(): Unit = {
     z(s"${START}UIO(Right(a))$END").assertHighlighted()
@@ -211,4 +225,9 @@ class SucceedRightInspectionTest extends SimplifySucceedEitherInspectionTest("ZI
     val result = z("UIO.right(a)")
     testQuickFix(text, result, hint)
   }
+
+}
+
+class SucceedRightInspectionTestZIO2 extends SucceedRightInspectionTest {
+  override protected def isZIO1 = false
 }

--- a/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedOptionInspectionTest.scala
@@ -7,11 +7,33 @@ abstract class SimplifyOptionInspectionTest(s: String)
   override protected val hint = s"Replace with $s"
 }
 
-class SucceedNoneInspectionTest extends SimplifyOptionInspectionTest("ZIO.none") {
+abstract class SucceedNoneInspectionTest extends SimplifyOptionInspectionTest("ZIO.none") {
 
   def test_succeed_None(): Unit = {
     z(s"${START}ZIO.succeed(None)$END").assertHighlighted()
     val text   = z("ZIO.succeed(None)")
+    val result = z("ZIO.none")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_succeed_None_type_no_highlight(): Unit =
+    z(s"${START}ZIO.succeed { val x = 1; None }$END").assertNotHighlighted()
+
+}
+
+class SucceedNoneInspectionTestZIO1 extends SucceedNoneInspectionTest {
+  override def isZIO1: Boolean = true
+
+  def test_effectTotal_None(): Unit = {
+    z(s"${START}ZIO.effectTotal(None)$END").assertHighlighted()
+    val text   = z("ZIO.effectTotal(None)")
+    val result = z("ZIO.none")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_effect_None(): Unit = {
+    z(s"${START}ZIO.effect(None)$END").assertHighlighted()
+    val text   = z("ZIO.effect(None)")
     val result = z("ZIO.none")
     testQuickFix(text, result, hint)
   }
@@ -29,9 +51,21 @@ class SucceedNoneInspectionTest extends SimplifyOptionInspectionTest("ZIO.none")
     val result = z("UIO.none")
     testQuickFix(text, result, hint)
   }
+
 }
 
-class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some") {
+class SucceedNoneInspectionTestZIO2 extends SucceedNoneInspectionTest {
+  override def isZIO1: Boolean = false
+
+  def test_attempt_None(): Unit = {
+    z(s"${START}ZIO.attempt(None)$END").assertHighlighted()
+    val text   = z("ZIO.attempt(None)")
+    val result = z("ZIO.none")
+    testQuickFix(text, result, hint)
+  }
+}
+
+abstract class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some") {
 
   def test_succeed_Some(): Unit = {
     z(s"${START}ZIO.succeed(Some(a))$END").assertHighlighted()
@@ -69,6 +103,11 @@ class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some")
     testQuickFix(text, result, hint)
   }
 
+}
+
+class SucceedSomeInspectionTestZIO1 extends SucceedSomeInspectionTest {
+  override def isZIO1: Boolean = true
+
   def test_UIO_Some(): Unit = {
     z(s"${START}UIO(Some(a))$END").assertHighlighted()
     val text   = z("UIO(Some(a))")
@@ -82,4 +121,8 @@ class SucceedSomeInspectionTest extends SimplifyOptionInspectionTest("ZIO.some")
     val result = z("UIO.some(a)")
     testQuickFix(text, result, hint)
   }
+}
+
+class SucceedSomeInspectionTestZIO2 extends SucceedSomeInspectionTest {
+  override def isZIO1: Boolean = false
 }

--- a/src/test/scala/zio/inspections/SimplifySucceedUnitInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifySucceedUnitInspectionTest.scala
@@ -1,0 +1,66 @@
+package zio.inspections
+
+import zio.intellij.inspections.simplifications.SimplifySucceedUnitInspection
+
+abstract class SimplifySucceedUnitInspectionTest extends ZSimplifyInspectionTest[SimplifySucceedUnitInspection] {
+  override protected val hint = s"Replace with ZIO.unit"
+
+  def test_succeed_Unit(): Unit = {
+    z(s"${START}ZIO.succeed(())$END").assertHighlighted()
+    val text   = z("ZIO.succeed(())")
+    val result = z("ZIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_succeed_Unit_type_no_highlight(): Unit =
+    z(s"${START}ZIO.succeed { val x = 1; () }$END").assertNotHighlighted()
+
+  def test_succeed_Unit_expected_type_no_highlight(): Unit =
+    z(s"val foo: UIO[Unit] = ${START}ZIO.succeed(1)$END").assertNotHighlighted()
+
+}
+
+class SimplifySucceedUnitInspectionTestZIO1 extends SimplifySucceedUnitInspectionTest {
+  override def isZIO1: Boolean = true
+
+  def test_effectTotal_Unit(): Unit = {
+    z(s"${START}ZIO.effectTotal(())$END").assertHighlighted()
+    val text   = z("ZIO.effectTotal(())")
+    val result = z("ZIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_effect_Unit(): Unit = {
+    z(s"${START}ZIO.effect(())$END").assertHighlighted()
+    val text   = z("ZIO.effect(())")
+    val result = z("ZIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_UIO_Unit(): Unit = {
+    z(s"${START}UIO(())$END").assertHighlighted()
+    val text   = z("UIO(())")
+    val result = z("UIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+  def test_UIO_apply_Unit(): Unit = {
+    z(s"${START}UIO.apply(())$END").assertHighlighted()
+    val text   = z("UIO.apply(())")
+    val result = z("UIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+}
+
+class SimplifySucceedUnitInspectionTestZIO2 extends SimplifySucceedUnitInspectionTest {
+  override def isZIO1: Boolean = false
+
+  def test_attempt_Unit(): Unit = {
+    z(s"${START}ZIO.attempt(())$END").assertHighlighted()
+    val text   = z("ZIO.attempt(())")
+    val result = z("ZIO.unit")
+    testQuickFix(text, result, hint)
+  }
+
+}


### PR DESCRIPTION
Closes https://github.com/zio/zio-intellij/issues/456. Apparently, we've already got most of the inspections. They just weren't working because in ZIO2 they are placed within `ZIOCompanionVersionSpecific` trait and plugin inspections couldn't recognize them.