### PR TITLE
add support for ZLayer provide macro

### DIFF
--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -379,8 +379,42 @@ package object inspections {
   val `ZIO.foreachParN`   = new ZIOCurried3StaticMemberReference("foreachParN")
   val `ZIO.partitionParN` = new ZIOCurried3StaticMemberReference("partitionParN")
 
-  val `ZLayer.fromEffect`     = new ZLayerStaticMemberReference("fromEffect")
-  val `ZLayer.fromEffectMany` = new ZLayerStaticMemberReference("fromEffectMany")
+  val `ZLayer.fromEffect`         = new ZLayerStaticMemberReference("fromEffect")
+  val `ZLayer.fromEffectMany`     = new ZLayerStaticMemberReference("fromEffectMany")
+  val `ZLayer.make`               = new ZLayerStaticMemberReference("make")
+  val `ZLayer.makeSome`           = new ZLayerStaticMemberReference("makeSome")
+  val `ZLayer.wire`               = new ZLayerStaticMemberReference("wire")
+  val `ZLayer.wireDebug`          = new ZLayerStaticMemberReference("wireDebug")
+  val `ZLayer.wireSome`           = new ZLayerStaticMemberReference("wireSome")
+  val `ZLayer.wireSomeDebug`      = new ZLayerStaticMemberReference("wireSomeDebug")
+  val `ZLayer.fromMagic`          = new ZLayerStaticMemberReference("fromMagic")
+  val `ZLayer.fromMagicDebug`     = new ZLayerStaticMemberReference("fromMagicDebug")
+  val `ZLayer.fromSomeMagic`      = new ZLayerStaticMemberReference("fromSomeMagic")
+  val `ZLayer.fromSomeMagicDebug` = new ZLayerStaticMemberReference("fromSomeMagicDebug")
+
+  object `ZLayer.makeLike` {
+    def unapply(expr: ScExpression): Option[(ZLayerType, ScExpression)] =
+      expr match {
+        case `ZLayer.make`(tpe, expr)           => Some((tpe, expr))
+        case `ZLayer.wire`(tpe, expr)           => Some((tpe, expr))
+        case `ZLayer.wireDebug`(tpe, expr)      => Some((tpe, expr))
+        case `ZLayer.fromMagic`(tpe, expr)      => Some((tpe, expr))
+        case `ZLayer.fromMagicDebug`(tpe, expr) => Some((tpe, expr))
+        case _                                  => None
+      }
+  }
+
+  object `ZLayer.makeSomeLike` {
+    def unapply(expr: ScExpression): Option[(ZLayerType, ScExpression)] =
+      expr match {
+        case `ZLayer.makeSome`(tpe, expr)           => Some((tpe, expr))
+        case `ZLayer.wireSome`(tpe, expr)           => Some((tpe, expr))
+        case `ZLayer.wireSomeDebug`(tpe, expr)      => Some((tpe, expr))
+        case `ZLayer.fromSomeMagic`(tpe, expr)      => Some((tpe, expr))
+        case `ZLayer.fromSomeMagicDebug`(tpe, expr) => Some((tpe, expr))
+        case _                                      => None
+      }
+  }
 
   object unit {
 

--- a/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ProvideMacroInspectionTest.scala
@@ -527,6 +527,85 @@ class ProvideSomeMacroZIO2SpecInspectionTest extends ProvideSomeMacroZIO2SpecIns
 class ProvideSomeSharedMacroZIO2SpecInspectionTest
     extends ProvideSomeMacroZIO2SpecInspectionTestBase("provideSomeShared")
 
+abstract class ProvideMacroZLayerInspectionTestBase extends ZScalaInspectionTest[ProvideMacroInspection] {
+  override protected def librariesLoaders: Seq[LibraryLoader] =
+    if (isZIO1) IvyManagedLoader("io.github.kitlangton" %% "zio-magic" % "0.3.12") +: super.librariesLoaders
+    else super.librariesLoaders
+
+  override protected def description                            = "Please provide layers for the following"
+  override protected def descriptionMatches(s: String): Boolean = s != null && s.startsWith(description)
+}
+
+abstract class ProvideMacroZIO1ZLayerInspectionTestBase(wire: String) extends ProvideMacroZLayerInspectionTestBase {
+  def testValidSimpleNoHighlighting(): Unit = z {
+    s"""import zio.magic._
+       |
+       |val layer: ULayer[Has[String]] = ???
+       |${r(s"ZLayer.$wire[Has[String]](layer)")}""".stripMargin
+  }.assertNotHighlighted()
+  def testValidSimpleHighlighting(): Unit = z {
+    s"""import zio.magic._
+       |
+       |val layer: ULayer[Has[String]] = ???
+       |${r(s"ZLayer.$wire[Has[String] with Has[Int]](layer)")}""".stripMargin
+  }.assertHighlighted()
+}
+class ProvideMacroZIO1ZLayerInspectionTest           extends ProvideMacroZIO1ZLayerInspectionTestBase("wire")
+class ProvideDebugMacroZIO1ZLayerInspectionTest      extends ProvideMacroZIO1ZLayerInspectionTestBase("wireDebug")
+class ProvideMagicMacroZIO1ZLayerInspectionTest      extends ProvideMacroZIO1ZLayerInspectionTestBase("fromMagic")
+class ProvideMagicDebugMacroZIO1ZLayerInspectionTest extends ProvideMacroZIO1ZLayerInspectionTestBase("fromMagicDebug")
+
+abstract class ProvideSomeMacroZIO1ZLayerInspectionTestBase(wireSome: String)
+    extends ProvideMacroZLayerInspectionTestBase {
+  def testValidSimpleNoHighlighting(): Unit = z {
+    s"""import zio.magic._
+       |
+       |val layer: ULayer[Has[String]] = ???
+       |${r(s"ZLayer.$wireSome[Has[Boolean], Has[String]](layer)")}""".stripMargin
+  }.assertNotHighlighted()
+  def testValidSimpleHighlighting(): Unit = z {
+    s"""import zio.magic._
+       |
+       |val layer: ULayer[Has[String]] = ???
+       |${r(s"ZLayer.$wireSome[Has[Boolean], Has[String] with Has[Int]](layer)")}""".stripMargin
+  }.assertHighlighted()
+}
+class ProvideSomeMacroZIO1ZLayerInspectionTest extends ProvideSomeMacroZIO1ZLayerInspectionTestBase("wireSome")
+class ProvideSomeDebugMacroZIO1ZLayerInspectionTest
+    extends ProvideSomeMacroZIO1ZLayerInspectionTestBase("wireSomeDebug")
+class ProvideSomeMagicMacroZIO1ZLayerInspectionTest
+    extends ProvideSomeMacroZIO1ZLayerInspectionTestBase("fromSomeMagic")
+class ProvideSomeMagicDebugMacroZIO1ZLayerInspectionTest
+    extends ProvideSomeMacroZIO1ZLayerInspectionTestBase("fromSomeMagicDebug")
+
+class ProvideMacroZIO2ZLayerInspectionTest extends ProvideMacroZLayerInspectionTestBase {
+  override protected def isZIO1 = false
+  def testValidSimpleNoHighlighting(): Unit = z {
+    s"""
+       |val layer: ULayer[String] = ???
+       |${r(s"ZLayer.make[String](layer)")}""".stripMargin
+  }.assertNotHighlighted()
+  def testValidSimpleHighlighting(): Unit = z {
+    s"""
+       |val layer: ULayer[String] = ???
+       |${r(s"ZLayer.make[String with Int](layer)")}""".stripMargin
+  }.assertHighlighted()
+}
+
+class ProvideSomeMacroZIO2ZLayerInspectionTest extends ProvideMacroZLayerInspectionTestBase {
+  override protected def isZIO1 = false
+  def testValidSimpleNoHighlighting(): Unit = z {
+    s"""
+       |val layer: ULayer[String] = ???
+       |${r(s"ZLayer.makeSome[Boolean, String](layer)")}""".stripMargin
+  }.assertNotHighlighted()
+  def testValidSimpleHighlighting(): Unit = z {
+    s"""
+       |val layer: ULayer[String] = ???
+       |${r(s"ZLayer.makeSome[Boolean, String with Int](layer)")}""".stripMargin
+  }.assertHighlighted()
+}
+
 // special test to expect _very_ specific error message
 // checking if types are rendered correctly
 class ProvideMacroInspectionRenderingTest extends ZScalaInspectionTest[ProvideMacroInspection] {


### PR DESCRIPTION
Last time I was too lazy to implement whole `ZLayer.make`/`Zlayer.wire` family. But now I'm missing it too much