### PR TITLE
ZIO 2.0 tests not supported in 2023.3

### DIFF
--- a/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestFramework.scala
@@ -16,14 +16,14 @@ import zio.intellij.utils.TypeCheckUtils.zioTestPackage
 import javax.swing.Icon
 import scala.annotation.tailrec
 
-final class Zio1TestFramework() extends ZTestFramework(ZIO1SpecFQN)
-final class Zio2TestFramework() extends ZTestFramework(ZIO2SpecFQN)
+final class Zio1TestFramework extends ZTestFramework(ZIO1SpecFQN, "1.x")
+final class Zio2TestFramework extends ZTestFramework(ZIO2SpecFQN, "2.x")
 
-sealed abstract class ZTestFramework(zSpecFqn: String) extends AbstractTestFramework {
+sealed abstract class ZTestFramework(zSpecFqn: String, zioVersion: String) extends AbstractTestFramework {
   override def getMarkerClassFQName: String = zSpecFqn
   override def getDefaultSuperClass: String = zSpecFqn
   override def testFileTemplateName: String = "ZIO Test Suite"
-  override def getName: String              = "ZIO Test"
+  override def getName: String              = s"ZIO Test ($zioVersion)"
   override def getIcon: Icon                = ZioIcon
 
   override def isTestMethod(element: PsiElement): Boolean = isTestMethod(element, checkAbstract = false)


### PR DESCRIPTION
It seems there was a change in how Test Frameworks are detected in 2023.3 - they are cached by the framework name and language of the project.

The ZIO plugin had two Test Framework definitions, for both ZIO 1.x and ZIO 2.x, but both had the same name ("ZIO Test"). This worked in the previous IntelliJ versions, but not in 2023.3.

Fixed by making the name unique per test framework.