### PR TITLE
Support ZLayer in NothingInContravariantPositionInspection

### DIFF
--- a/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
+++ b/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
@@ -23,7 +23,7 @@ object TypeCheckUtils {
   val zioSpecTypes    = List("zio.test.Spec", "zio.test.SpecVersionSpecific")
   // ZStreams API signatures sometimes slightly differ from regular one (no `.tapBoth`, different `.tap`)
   val zioLike_notStream = zioTypes ++ managedTypes ++ extraTypes ++ zioTestAsserts
-  val zioLikePackages   = zioLike_notStream ++ zioStreamTypes
+  val zioLikePackages   = zioLike_notStream ++ zioStreamTypes ++ zioLayerTypes
 
   def fromZioLike(r: ScExpression): Boolean =
     isOfClassFrom(r, zioLikePackages)

--- a/src/test/scala/zio/inspections/NothingInContravariantPositionInspectionTest.scala
+++ b/src/test/scala/zio/inspections/NothingInContravariantPositionInspectionTest.scala
@@ -13,6 +13,9 @@ class NothingInContravariantPositionInspectionTest
   def test_value_def(): Unit =
     z(s"val foo: ZIO[${START}Nothing$END, Nothing, Unit] = ???").assertHighlighted()
 
+  def test_zlayer_def(): Unit =
+    z(s"val foo: ZLayer[${START}Nothing$END, Nothing, Unit] = ???").assertHighlighted()
+
   def test_type_alias(): Unit =
     z(s"type Test[+A] = ZIO[${START}Nothing$END, Nothing, A] = ???").assertHighlighted()
 


### PR DESCRIPTION
Inspects ZLayer when mistakingly using `Nothing` in the `RIn` position (i.e. `ZLayer[Nothing, Nothing, Unit]`)