### PR TITLE
Version bump

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 import org.jetbrains.sbtidea.{AutoJbr, JbrPlatform}
 
-lazy val scala213           = "2.13.12"
-lazy val scalaPluginVersion = "2024.2.13"
-lazy val minorVersion       = "1"
+lazy val scala213           = "2.13.14"
+lazy val scalaPluginVersion = "2024.2.26"
+lazy val minorVersion       = "2"
 lazy val buildVersion       = sys.env.getOrElse("ZIO_INTELLIJ_BUILD_NUMBER", minorVersion)
 lazy val pluginVersion      = s"2024.2.34.$buildVersion"
 
 ThisBuild / intellijPluginName := "zio-intellij"
-ThisBuild / intellijBuild := "242.20224.91"
+ThisBuild / intellijBuild := "242.22855.74"
 ThisBuild / jbrInfo := AutoJbr(explicitPlatform = Some(JbrPlatform.osx_aarch64))
 
 Global / intellijAttachSources := true


### PR DESCRIPTION
This PR contains possible fixes for https://github.com/zio/zio-intellij/issues/475
Should fix the following error
```
Caused by: java.lang.NoSuchMethodError: 'java.lang.String org.jetbrains.plugins.scala.codeInspection.collections.package$.invocationText(org.jetbrains.plugins.scala.lang.psi.api.expr.ScExpression, java.lang.String, scala.collection.immutable.Seq)'
```
I have no idea what causes another error
```
java.lang.ClassCastException: class zio.intellij.utils.ZioVersion$$anon$1 cannot be cast to class zio.intellij.utils.ZioVersion (zio.intellij.utils.ZioVersion$$anon$1 is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @6379227f; zio.intellij.utils.ZioVersion is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @6360a097)
```
hopefully it'll be fixed automatically