### PR TITLE
Add inspection for "ZIO.fail(throw"

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -313,6 +313,12 @@
                          shortName="IncorrectPreludeNewTypeAliasInspection" level="ERROR"
                          enabledByDefault="true" language="Scala"/>
 
+        <localInspection implementationClass="zio.intellij.inspections.mistakes.ZIOFailThrowInspection"
+                         displayName="Detects erroneous throw inside `ZIO.fail` instead of returning exception value"
+                         groupPath="Scala,ZIO" groupName="Inspections"
+                         shortName="ZIOFailThrowInspection" level="WARNING"
+                         enabledByDefault="true" language="Scala"/>
+
         <intentionAction>
             <category>ZIO/Suggestions</category>
             <className>zio.intellij.intentions.suggestions.SuggestTypeAlias</className>

--- a/src/main/scala/zio/intellij/inspections/mistakes/ZIOFailThrowInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/ZIOFailThrowInspection.scala
@@ -9,14 +9,14 @@ import zio.intellij.inspections.`ZIO.fail`
 class ZIOFailThrowInspection extends LocalInspectionTool {
 
   override def buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitorSimple = {
-    case f @ `ZIO.fail`(_, b: ScThrow) =>
-      b.expression match {
-        case Some(expr) =>
+    case fail @ `ZIO.fail`(_, scThrow: ScThrow) =>
+      scThrow.expression match {
+        case Some(throwableExpr) =>
           holder.registerProblem(
-            f,
+            fail,
             ZIOFailThrowInspection.message,
             ProblemHighlightType.WARNING,
-            new QuickFix(b, expr)
+            new QuickFix(scThrow, throwableExpr)
           )
         case None =>
       }

--- a/src/main/scala/zio/intellij/inspections/mistakes/ZIOFailThrowInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/mistakes/ZIOFailThrowInspection.scala
@@ -1,0 +1,39 @@
+package zio.intellij.inspections.mistakes
+
+import com.intellij.codeInspection.{LocalInspectionTool, ProblemHighlightType, ProblemsHolder}
+import com.intellij.openapi.project.Project
+import org.jetbrains.plugins.scala.codeInspection.{AbstractFixOnPsiElement, PsiElementVisitorSimple}
+import org.jetbrains.plugins.scala.lang.psi.api.expr.{ScExpression, ScThrow}
+import zio.intellij.inspections.`ZIO.fail`
+
+class ZIOFailThrowInspection extends LocalInspectionTool {
+
+  override def buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitorSimple = {
+    case f @ `ZIO.fail`(_, b: ScThrow) =>
+      b.expression match {
+        case Some(expr) =>
+          holder.registerProblem(
+            f,
+            ZIOFailThrowInspection.message,
+            ProblemHighlightType.WARNING,
+            new QuickFix(b, expr)
+          )
+        case None =>
+      }
+    case _ =>
+  }
+
+  final class QuickFix(
+    val toReplace: ScExpression,
+    val replaceWith: ScExpression
+  ) extends AbstractFixOnPsiElement(s"Remove throw from ZIO.fail", toReplace) {
+
+    override protected def doApplyFix(element: ScExpression)(implicit project: Project): Unit =
+      element.replace(replaceWith)
+  }
+
+}
+
+object ZIOFailThrowInspection {
+  val message = "Mistaken throwing of the exception inside ZIO.fail"
+}

--- a/src/main/scala/zio/intellij/testsupport/zio1/runner/TestRunnerResolveService.scala
+++ b/src/main/scala/zio/intellij/testsupport/zio1/runner/TestRunnerResolveService.scala
@@ -15,7 +15,7 @@ import TestRunnerResolveService.ResolveError.DownloadError
 import TestRunnerResolveService._
 import zio.intellij.utils.{BackgroundTask, ScalaVersionHack, ZioVersion}
 
-import java.net.{URI, URL, URLClassLoader}
+import java.net.{URL, URLClassLoader}
 import java.util.concurrent.ConcurrentHashMap
 import scala.beans.BeanProperty
 import scala.collection.mutable

--- a/src/main/scala/zio/intellij/testsupport/zio1/runner/TestRunnerResolveService.scala
+++ b/src/main/scala/zio/intellij/testsupport/zio1/runner/TestRunnerResolveService.scala
@@ -15,7 +15,7 @@ import TestRunnerResolveService.ResolveError.DownloadError
 import TestRunnerResolveService._
 import zio.intellij.utils.{BackgroundTask, ScalaVersionHack, ZioVersion}
 
-import java.net.{URL, URLClassLoader}
+import java.net.{URI, URL, URLClassLoader}
 import java.util.concurrent.ConcurrentHashMap
 import scala.beans.BeanProperty
 import scala.collection.mutable

--- a/src/test/scala/zio/inspections/ZIOFailThrowInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZIOFailThrowInspectionTest.scala
@@ -1,0 +1,22 @@
+package zio.inspections
+
+import zio.intellij.inspections.mistakes.ZIOFailThrowInspection
+
+class ZIOFailThrowInspectionTest extends ZScalaInspectionTest[ZIOFailThrowInspection] {
+
+  override protected def description: String = ZIOFailThrowInspection.message
+  val hint = "Remove throw from ZIO.fail"
+
+  def test_throw_inside_zio_fail(): Unit = {
+    z(s"""for {
+         |  x <- ${START}ZIO.fail(throw new RuntimeException("FAIL"))${END}
+         |} yield ()""".stripMargin).assertHighlighted()
+    val text   = z(s"""for {
+                      |  x <- ZIO.fail(throw new RuntimeException("FAIL"))
+                      |} yield ()""".stripMargin)
+    val result = z(s"""for {
+                      |  x <- ZIO.fail(new RuntimeException("FAIL"))
+                      |} yield ()""".stripMargin)
+    testQuickFix(text, result, hint)
+  }
+}


### PR DESCRIPTION
Using `ZIO.fail(throw` causes exception to be thrown instead of being used as value.