### PR TITLE
fix NoClassDefFoundError and NoSuchMethodError errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 import org.jetbrains.sbtidea.{AutoJbr, JbrPlatform}
 
 lazy val scala213           = "2.13.16"
-lazy val scalaPluginVersion = "2025.1.724:Nightly"
+lazy val scalaPluginVersion = "2025.1.24"
 lazy val minorVersion       = "0"
 lazy val buildVersion       = sys.env.getOrElse("ZIO_INTELLIJ_BUILD_NUMBER", minorVersion)
-lazy val pluginVersion      = s"2025.1.40.$buildVersion"
+lazy val pluginVersion      = s"2025.1.41.$buildVersion"
 
 ThisBuild / intellijPluginName := "zio-intellij"
 ThisBuild / intellijBuild := "251"
@@ -67,7 +67,7 @@ def newProject(projectName: String, base: File): Project =
     libraryDependencies ++= Seq(
       "junit"             % "junit"             % "4.13.2" % Test,
       "com.github.sbt"    % "junit-interface"   % "0.13.3" % Test,
-      "org.junit.jupiter" % "junit-jupiter-api" % "5.11.1" % Test
+      "org.junit.jupiter" % "junit-jupiter-api" % "5.13.0" % Test
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-s", "-a", "+c", "+q"),
     intellijPlugins := Seq(

--- a/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
+++ b/src/main/scala/zio/intellij/utils/TypeCheckUtils.scala
@@ -11,16 +11,28 @@ object TypeCheckUtils {
   val zioCompanionSpecificTypes      = List("zio.ZIOCompanionVersionSpecific", "zio.ZIOCompanionPlatformSpecific")
   val zioLayerCompanionSpecificTypes = List("zio.ZLayerCompanionVersionSpecific", "zio.magic.ZLayerCompanionOps")
 
-  val zioTypes        = ZioTypes.values.map(_.fqName) :+ "zio.ZIOPlatformSpecific" :+ "zio.ZIOVersionSpecific"
+  val zioTypes =
+    ZioTypes.values.map(_.fqName) ++
+      ZioTypes.values.map(_.fqName).map(tpe => s"$tpe._") :+
+      "zio.ZIOPlatformSpecific" :+
+      "zio.ZIOVersionSpecific" :+
+      "zio.ProvideSomeLayerPartiallyApplied"
+
   val zioLayerTypes   = ZLayerTypes.values.map(_.fqName)
   val zioSinkTypes    = List("zio.stream.ZSink")
-  val zioStreamTypes  = List("zio.stream.ZStream")
-  val managedTypes    = List("zio.ZManaged")
+  val zioStreamTypes  = List("zio.stream.ZStream", "zio.stream.ZStream._")
+  val managedTypes    = List("zio.ZManaged", "zio.ZManaged._")
   val extraTypes      = List("zio.Fiber", "zio.ZQueue", "zio.ZRef", "zio.ZRefM", "zio.ZQuery")
   val zioTestAsserts  = List("zio.test.Assertion._", "zio.test.BoolAlgebra", "zio.test.BoolAlgebraM", "zio.test.Assert")
   val zioTestPackage  = List("zio.test._")
   val zioMagicPackage = List("zio.magic._")
-  val zioSpecTypes    = List("zio.test.Spec", "zio.test.SpecVersionSpecific")
+  val zioSpecTypes = List(
+    "zio.test.Spec",
+    "zio.test.SpecVersionSpecific",
+    "zio.test.ProvideSomePartiallyApplied",
+    "zio.test.ProvideSomeSharedPartiallyApplied"
+  )
+
   // ZStreams API signatures sometimes slightly differ from regular one (no `.tapBoth`, different `.tap`)
   val zioLike_notStream = zioTypes ++ managedTypes ++ extraTypes ++ zioTestAsserts
   val zioLikePackages   = zioLike_notStream ++ zioStreamTypes ++ zioLayerTypes

--- a/src/test/scala/zio/inspections/IfGuardInsteadOfWhenInspectionTest.scala
+++ b/src/test/scala/zio/inspections/IfGuardInsteadOfWhenInspectionTest.scala
@@ -36,6 +36,6 @@ class IfGuardInsteadOfWhenInspectionTest extends ZScalaInspectionTest[IfGuardIns
                       |  y <- ZIO.succeed(6)
                       |} yield ()""".stripMargin)
 
-    testQuickFix(text, result, hint)
+    testQuickFixes(text, result, hint)
   }
 }


### PR DESCRIPTION
this MR should fix `No...Error`s occurring due to new implicit `Context` parameter
fixes https://github.com/zio/zio-intellij/issues/496
fixes https://github.com/zio/zio-intellij/issues/497
fixes https://github.com/zio/zio-intellij/issues/498
fixes https://github.com/zio/zio-intellij/issues/500
