### PR TITLE
disable .as simplifications when method returns Unit

### DIFF
--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -2,7 +2,7 @@ package zio.intellij
 
 import com.intellij.psi.{PsiAnnotation, PsiClass, PsiElement}
 import org.jetbrains.plugins.scala.codeInspection.collections._
-import org.jetbrains.plugins.scala.extensions.{childOf, PsiClassExt}
+import org.jetbrains.plugins.scala.extensions.PsiClassExt
 import org.jetbrains.plugins.scala.lang.psi.api.base.patterns.{ScPattern, ScReferencePattern, ScWildcardPattern}
 import org.jetbrains.plugins.scala.lang.psi.api.expr._
 import org.jetbrains.plugins.scala.lang.psi.api.statements.ScFunctionDefinition
@@ -10,6 +10,7 @@ import org.jetbrains.plugins.scala.lang.psi.api.statements.params.ScParameter
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.ScNamedElement
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.{ScMember, ScObject, ScTemplateDefinition, ScTrait}
 import org.jetbrains.plugins.scala.lang.psi.types.ScType
+import org.jetbrains.plugins.scala.lang.psi.types.result.Typeable
 import org.jetbrains.plugins.scala.lang.refactoring.util.ScalaNamesUtil
 import zio.intellij.utils.TypeCheckUtils._
 import zio.intellij.utils.types._
@@ -572,6 +573,22 @@ package object inspections {
             case _                                           => None
           }
         case _ => None
+      }
+  }
+
+  object NonUnit {
+    def unapply(expr: ScExpression): Option[ScExpression] =
+      expr match {
+        case Typeable(tpe) if !tpe.isUnit => Some(expr)
+        case _                            => None
+      }
+  }
+
+  object NonZIOUnit {
+    def unapply(expr: ScExpression): Option[ScExpression] =
+      expr match {
+        case Typeable(`ZIO[R, E, A]`(_, _, a)) if !a.isUnit => Some(expr)
+        case _                                              => None
       }
   }
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyZipInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyZipInspection.scala
@@ -65,9 +65,9 @@ object ZipRightSimplificationType         extends BaseZipOneSimplificationType(`
 object ZipRightOperatorSimplificationType extends BaseZipOneOperatorSimplificationType(`.flatMap`, "*>")
 object ZipRightToSucceedSimplificationType extends BaseZipToSucceedSimplificationType {
   override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
-    case qual `.*>` `ZIO.succeed`(_, arg)       => Some(simplify(expr, qual, arg))
-    case qual `.zipRight` `ZIO.succeed`(_, arg) => Some(simplify(expr, qual, arg))
-    case _                                      => None
+    case qual `.*>` `ZIO.succeed`(_, NonUnit(arg))       => Some(simplify(expr, qual, arg))
+    case qual `.zipRight` `ZIO.succeed`(_, NonUnit(arg)) => Some(simplify(expr, qual, arg))
+    case _                                               => None
   }
 }
 
@@ -75,8 +75,8 @@ object ZipLeftSimplificationType         extends BaseZipOneSimplificationType(`.
 object ZipLeftOperatorSimplificationType extends BaseZipOneOperatorSimplificationType(`.tap_notStream`, "<*")
 object ZipLeftToSucceedSimplificationType extends BaseZipToSucceedSimplificationType {
   override def getSimplification(expr: ScExpression): Option[Simplification] = expr match {
-    case `ZIO.succeed`(_, arg) `.<*` qual      => Some(simplify(expr, qual, arg))
-    case `ZIO.succeed`(_, arg) `.zipLeft` qual => Some(simplify(expr, qual, arg))
-    case _                                     => None
+    case `ZIO.succeed`(_, NonUnit(arg)) `.<*` NonZIOUnit(qual)      => Some(simplify(expr, qual, arg))
+    case `ZIO.succeed`(_, NonUnit(arg)) `.zipLeft` NonZIOUnit(qual) => Some(simplify(expr, qual, arg))
+    case _                                                          => None
   }
 }

--- a/src/test/scala/zio/inspections/SimplifyZipLeftInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyZipLeftInspectionTest.scala
@@ -147,4 +147,22 @@ class SimplifySucceedToZipLeftInspectionTest extends ZSimplifyInspectionTest[Sim
     testQuickFix(text, result, hint)
   }
 
+  def test_succeed_to_zipLeft_left_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed(unit()).zipLeft(f("Carlos Alonso"))$END""").assertNotHighlighted()
+
+  def test_zipLeft_infix_invocation_to_succeed_left_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed(unit()) zipLeft f("Carlos Alonso")$END""").assertNotHighlighted()
+
+  def test_zipLeft_operator_to_succeed_left_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed(unit()) <* f("Carlos Alonso")$END""").assertNotHighlighted()
+
+  def test_succeed_to_zipLeft_right_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed("Fernando Fader").zipLeft(logger.log("Carlos Alonso"))$END""").assertNotHighlighted()
+
+  def test_zipLeft_infix_invocation_to_succeed_right_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed("Fernando Fader") zipLeft logger.log("Carlos Alonso")$END""").assertNotHighlighted()
+
+  def test_zipLeft_operator_to_succeed_right_unit_no_highlight(): Unit =
+    z(s"""${START}ZIO.succeed("Fernando Fader") <* logger.log("Carlos Alonso")$END""").assertNotHighlighted()
+
 }

--- a/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyZipRightInspectionTest.scala
@@ -141,4 +141,13 @@ class SimplifyZipRightToSucceedInspectionTest extends ZSimplifyInspectionTest[Si
     testQuickFix(text, result, hint)
   }
 
+  def test_zipRight_to_succeed_unit_no_highlight(): Unit =
+    z(s"""${START}f("Fernando Fader").zipRight(ZIO.succeed(unit()))$END""").assertNotHighlighted()
+
+  def test_zipRight_infix_invocation_to_succeed_unit_no_highlight(): Unit =
+    z(s"""${START}f("Fernando Fader") zipRight ZIO.succeed(unit())$END""").assertNotHighlighted()
+
+  def test_zipRight_operator_to_succeed_unit_no_highlight(): Unit =
+    z(s"""${START}f("Fernando Fader") *> ZIO.succeed(unit())$END""").assertNotHighlighted()
+
 }

--- a/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
+++ b/src/test/scala/zio/inspections/ZSimplifyInspectionTest.scala
@@ -34,8 +34,9 @@ trait ZInspectionTestBase[T <: LocalInspectionTool] { base: ScalaInspectionTestB
        |  val a: String = "hello"
        |  val b = ZIO.unit
        |  val o: Option[Int] = Some(1)
-       |  def f(a: Any): ZIO[Any, Throwable, Unit] = ???
-       |  def f(a: Any, b: Any): ZIO[Any, Throwable, Unit] = ???
+       |  def f(a: Any): ZIO[Any, Throwable, Any] = ???
+       |  def f(a: Any, b: Any): ZIO[Any, Throwable, Any] = ???
+       |  def unit(): Unit = ()
        |
        |  def foo = {
        |${s.split("\n").map(l => "    " + l).mkString("\n")}


### PR DESCRIPTION
`.as` simplification for `zipLeft` / `zipRight` behave weirdly and sometimes produce incorrect (though _technically_ correct) code. E.g. consider the following 

```scala
import zio._
def log(a: Any): Unit = ???

// 1
ZIO.succeed("before") *> ZIO.succeed(log("after"))
// Suggested simplification. Fine but hides actual intention
ZIO.succeed("before").as(log("after"))

// 2
ZIO.succeed {
  log("before")
  "before"
} <* ZIO.log("after")

// suggested simplification. Incorrect order leads to bad logs
ZIO.log("after").as {
  log("before")
  "before"
}

// 3
ZIO.succeed(log("before")) <* ZIO.succeed {
  log("after")
  "after"
}

// suggested simplification
ZIO.succeed {
  log("after")
  "after"
}.as(log("before"))
```

Those simplification work great when `ZIO.succed(???)` wraps something without side-effects. However, it's also a common pattern to wrap simple side-effects such as logging. Since those inspections are useful in general, disabling them globally doesn't seem like a good idea. Perhaps this simple fix will get rid of annoying false-positives