### PR TITLE
Fix collectAll inspection on maps

### DIFF
--- a/src/main/scala/zio/intellij/inspections/package.scala
+++ b/src/main/scala/zio/intellij/inspections/package.scala
@@ -351,10 +351,11 @@ package object inspections {
       }
   }
 
-  val scalaFuture = new ReturnTypeReference(Set("scala.concurrent.Future"))
-  val scalaTry    = new ReturnTypeReference(Set("scala.util.Try", "scala.util.Success", "scala.util.Failure"))
-  val scalaOption = new ReturnTypeReference(Set("scala.Option", "scala.Some", "scala.None"))
-  val scalaEither = new ReturnTypeReference(Set("scala.util.Either", "scala.util.Left", "scala.util.Right"))
+  val scalaFuture       = new ReturnTypeReference(Set("scala.concurrent.Future"))
+  val scalaTry          = new ReturnTypeReference(Set("scala.util.Try", "scala.util.Success", "scala.util.Failure"))
+  val scalaOption       = new ReturnTypeReference(Set("scala.Option", "scala.Some", "scala.None"))
+  val scalaEither       = new ReturnTypeReference(Set("scala.util.Either", "scala.util.Left", "scala.util.Right"))
+  val scalaImmutableMap = new ReturnTypeReference(Set("scala.collection.immutable.Map"))
 
   class TypeReference(typeFQNs: Set[String]) {
 

--- a/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
+++ b/src/main/scala/zio/intellij/inspections/simplifications/SimplifyCollectAllInspection.scala
@@ -25,7 +25,8 @@ sealed abstract class BaseCollectAllSimplificationType(methodName: String, metho
         .highlightAll
 
     expr match {
-      case methodExtractor(zioType, xs `.map` f) => Some(replacement(zioType, xs, f))
+      case methodExtractor(zioType, xs `.map` f)
+        if scalaImmutableMap.unapply(xs).isEmpty => Some(replacement(zioType, xs, f))
       case _                                     => None
     }
   }

--- a/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
+++ b/src/test/scala/zio/inspections/SimplifyCollectAllInspectionTest.scala
@@ -58,6 +58,14 @@ abstract class CollectAllInspectionTest(methodToReplace: String, methodToReplace
     }
     testQuickFix(text, result, hint)
   }
+
+  def testMapReplacement(): Unit = if (methodToReplace != "collectAllParN") {
+    val text = z(
+      s"""
+         |val m: Map[Int, Int] = Map(1 -> 2)
+         |ZIO.$methodToReplace(m map { case (k, v) => ZIO.succeed(v) })""".stripMargin)
+    checkTextHasNoErrors(text)
+  }
 }
 
 class SimplifyCollectAllToForeachTest


### PR DESCRIPTION
`ZIO.foreach` has a special overloaded definition if the collection it is applied to is of type `immutable.Map`. In this case the `SimplifyCollectAllInspection` does not yield the correct result. This PR aims to fix this. See the unit test for detailed information.