### PR TITLE
fix ZIO test runner

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -16,7 +16,7 @@ object Versions {
 
   val minorVersion: String  = "0"
   val buildVersion: String  = sys.env.getOrElse("ZIO_INTELLIJ_BUILD_NUMBER", minorVersion)
-  val pluginVersion: String = s"2026.1.2.$buildVersion"
+  val pluginVersion: String = s"2026.1.3.$buildVersion"
 
   val IntellijTestFrameworkVersion: String = intellijVersion_ForManagedIntellijDependencies
 

--- a/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
+++ b/src/main/scala/zio/intellij/testsupport/ZTestRunConfiguration.scala
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.InvalidDataException
 import com.intellij.psi.PsiClass
 import com.intellij.testIntegration.TestFramework
 import com.intellij.util.PathUtil
+import com.intellij.util.ui.UIUtil
 import org.jetbrains.plugins.scala.extensions._
 import org.jetbrains.plugins.scala.lang.psi.api.toplevel.typedef.ScObject
 import org.jetbrains.plugins.scala.testingSupport.test.CustomTestRunnerBasedStateProvider.TestFrameworkRunnerInfo
@@ -157,17 +158,19 @@ sealed abstract class ZTestRunConfiguration(project: Project, configurationFacto
       val processHandler = startProcess()
 
       val consoleView: ConsoleView =
-        if (useIntegratedRunner) {
-          val consoleProperties = new ZTestFrameworkConsoleProperties(self, executor)
-          SMTestRunnerConnectionUtil.createAndAttachConsole(
-            consoleProperties.getTestFrameworkName,
-            processHandler,
-            consoleProperties
-          )
-        } else {
-          val console = new ConsoleViewImpl(project, true)
-          console.attachToProcess(processHandler)
-          console
+        UIUtil.invokeAndWaitIfNeeded { () =>
+          if (useIntegratedRunner) {
+            val consoleProperties = new ZTestFrameworkConsoleProperties(self, executor)
+            SMTestRunnerConnectionUtil.createAndAttachConsole(
+              consoleProperties.getTestFrameworkName,
+              processHandler,
+              consoleProperties
+            )
+          } else {
+            val console = new ConsoleViewImpl(project, true)
+            console.attachToProcess(processHandler)
+            console
+          }
         }
 
       // TODO figure out whether we need a dedicated testConsoleView


### PR DESCRIPTION
Fixes https://github.com/zio/zio-intellij/issues/548
Perform console creation at [Event Dispatch Thread](https://docs.oracle.com/javase/tutorial/uiswing/concurrency/dispatch.html) to match the approach used in [ScalaTest runner](https://github.com/JetBrains/intellij-scala/blob/50f8eb1e7e26cfb7928c4fc84e0bdb865fe1e0e8/scala/test-integration/testing-support/src/org/jetbrains/plugins/scala/testingSupport/test/ScalaTestFrameworkCommandLineState.scala#L186) (although it's still unclear why it's broken now)
Given how far ScalaTest runner differs from ZIO test, perhaps this one needs an overhaul but that's an issue for another day