### PR TITLE
Add BSP environment support for ZIO Test run/debug configuration

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -339,7 +339,7 @@
         <runLineMarkerContributor implementationClass="zio.intellij.testsupport.ZTestRunLineMarkerProvider"
                                   language="Scala" order="first"/>
 
-
+        <bspEnvironmentRunnerExtension implementation="zio.intellij.testsupport.bsp.BspEnvironmentZioTestRunnerExtension"/>
 
         <postStartupActivity implementation="zio.intellij.startup.ZioPluginVersionCheckActivity"/>
 

--- a/src/main/scala/zio/intellij/testsupport/bsp/BspEnvironmentZioTestRunnerExtension.scala
+++ b/src/main/scala/zio/intellij/testsupport/bsp/BspEnvironmentZioTestRunnerExtension.scala
@@ -1,0 +1,26 @@
+package zio.intellij.testsupport.bsp
+
+import com.intellij.execution.configurations.RunConfiguration
+import org.jetbrains.bsp.project.test.environment.{BspEnvironmentRunnerExtension, ExecutionEnvironmentType}
+import org.jetbrains.plugins.scala.testingSupport.test.testdata.{AllInPackageTestData, ClassTestData}
+import zio.intellij.testsupport.ZTestRunConfiguration
+
+import scala.jdk.CollectionConverters._
+
+private final class BspEnvironmentZioTestRunnerExtension extends BspEnvironmentRunnerExtension {
+  override def runConfigurationSupported(config: RunConfiguration): Boolean =
+    config.isInstanceOf[ZTestRunConfiguration]
+
+  override def environmentType: ExecutionEnvironmentType = ExecutionEnvironmentType.TEST
+
+  override def classes(config: RunConfiguration): Option[List[String]] =
+    config match {
+      case zioTestConfig: ZTestRunConfiguration =>
+        zioTestConfig.testConfigurationData match {
+          case data: AllInPackageTestData => Some(data.classBuf.asScala.toList)
+          case data: ClassTestData        => Some(List(data.testClassPath))
+          case _                          => None
+        }
+      case _ => None
+    }
+}


### PR DESCRIPTION
This enables adding `Use BSP environment` as `Before launch` task to ZIO Test run/debug configurations for projects imported using [BSP](https://www.jetbrains.com/help/idea/bsp-support.html).

Would love to add a test for this feature, but I have no idea how/what/where. I tested this manually, have been using a locally built version for a few weeks now, seems to work fine.